### PR TITLE
Make marked text selectable

### DIFF
--- a/packages/@expressive-code/plugin-text-markers/src/styles.ts
+++ b/packages/@expressive-code/plugin-text-markers/src/styles.ts
@@ -133,6 +133,7 @@ export function getTextMarkersBaseStyles(theme: ExpressiveCodeTheme, coreStyles:
 					border-radius: var(--radius-l) var(--radius-r) var(--radius-r) var(--radius-l);
 					border: var(--border) solid var(--inline-marker-border-color);
 					border-inline-width: var(--border-l) var(--border-r);
+					pointer-events: none;
 				}
 			}
 		}


### PR DESCRIPTION
Hi there! It's maybe a bit early to contribute, but anyways, I'll try my luck 😅

When marking substrings of code blocks, the `.ec-line mark::before` prevents the user from selecting the underlying text. Adding `pointer-events: none` fixes this.

