### PR TITLE
Fix non-working copy buttons in dynamic content

### DIFF
--- a/.changeset/odd-grapes-sell.md
+++ b/.changeset/odd-grapes-sell.md
@@ -1,0 +1,8 @@
+---
+'@expressive-code/plugin-frames': patch
+'astro-expressive-code': patch
+'expressive-code': patch
+'remark-expressive-code': patch
+---
+
+Fix non-working copy buttons in dynamically loaded content


### PR DESCRIPTION
Adds support for dynamically added copy buttons to `@expressive-code/plugin-frames`.

In addition to initializing all copy buttons that exist on the page when first loading the JS module, the new code now also registers a `MutationObserver` to handle any new buttons added later.

This should fix non-working copy buttons in cases when the page dynamically loads more content or replaces existing content (e.g. SPA scenarios as reported in #16).
