### PR TITLE
Allow disabling themed scrollbars and selections

### DIFF
--- a/.changeset/polite-crews-applaud.md
+++ b/.changeset/polite-crews-applaud.md
@@ -1,0 +1,10 @@
+---
+'remark-expressive-code': minor
+'@expressive-code/core': minor
+'astro-expressive-code': minor
+'expressive-code': minor
+---
+
+Add config options `useThemedScrollbars` and `useThemedSelectionColors`. Thanks @Princesseuh!
+
+Both options default to `true`. Set any of them to `false` to prevent themes from customizing their appearance and render them using the browser's default style.

--- a/packages/@expressive-code/core/README.md
+++ b/packages/@expressive-code/core/README.md
@@ -33,7 +33,7 @@ The core package of Expressive Code, an engine for presenting source code on the
 
 Using this core package directly is **only recommended for advanced use cases**.
 
-Unless you're a plugin or integration author, you should probably use a higher-level package like `remark-expressive-code` instead of this one.
+Unless you're a plugin or integration author, you should probably use a higher-level package like [`astro-expressive-code`](https://www.npmjs.com/package/astro-expressive-code) or [`remark-expressive-code`](https://www.npmjs.com/package/remark-expressive-code) instead of this one.
 
 ## Installation
 
@@ -92,6 +92,22 @@ See above for a [usage example](#usage-example).
       Defaults to the `github-dark` theme bundled with Shiki.
 
       See [`ExpressiveCodeTheme`](#expressivecodetheme) for more information, including how to load your own themes.
+
+    - `useThemedScrollbars?: boolean`
+
+      Whether the theme is allowed to style the scrollbars. Defaults to `true`.
+
+      If set to `false`, scrollbars will be rendered using the browser's default style.
+
+      Note that you can override the individual scrollbar colors defined by the theme using the `styleOverrides` option.
+
+    - `useThemedSelectionColors?: boolean`
+
+      Whether the theme is allowed to style selected text. Defaults to `true`.
+
+      If set to `false`, selected text will be rendered using the browser's default style.
+
+      Note that you can override the individual selection colors defined by the theme using the `styleOverrides` option.
 
     - `styleOverrides: Partial<UnresolvedCoreStyleSettings<CoreStyleSettings>>`
 

--- a/packages/@expressive-code/core/src/common/core-styles.ts
+++ b/packages/@expressive-code/core/src/common/core-styles.ts
@@ -77,7 +77,11 @@ export type ResolvedCoreStyles = ResolvedStyleSettings<CoreStyleSettings>
 
 export const codeLineClass = 'ec-line'
 
-export function getCoreBaseStyles({ coreStyles }: { theme: ExpressiveCodeTheme; coreStyles: ResolvedCoreStyles }) {
+export function getCoreBaseStyles(options: { theme: ExpressiveCodeTheme; coreStyles: ResolvedCoreStyles; useThemedScrollbars: boolean; useThemedSelectionColors: boolean }) {
+	const { coreStyles } = options
+	const ifThemedScrollbars = (css: string) => (options.useThemedScrollbars ? css : '')
+	const ifThemedSelectionColors = (css: string) => (options.useThemedSelectionColors ? css : '')
+
 	return `
 		font-family: ${coreStyles.uiFontFamily};
 		font-size: ${coreStyles.uiFontSize};
@@ -90,10 +94,10 @@ export function getCoreBaseStyles({ coreStyles }: { theme: ExpressiveCodeTheme; 
 			box-sizing: border-box;
 		}
 
-		::selection {
+		${ifThemedSelectionColors(`::selection {
 			background: ${coreStyles.uiSelectionBackground};
 			color: ${coreStyles.uiSelectionForeground};
-		}
+		}`)}
 
 		pre {
 			display: flex;
@@ -123,12 +127,14 @@ export function getCoreBaseStyles({ coreStyles }: { theme: ExpressiveCodeTheme; 
 				--padding-inline: ${coreStyles.codePaddingInline};
 			}
 
-			::selection {
+			${ifThemedSelectionColors(`::selection {
 				background: ${coreStyles.codeSelectionBackground};
-			}
+			}`)}
 
-			/* Show minimal horizontal scrollbar if required */
+			/* Show horizontal scrollbar if required */
 			overflow-x: auto;
+
+			${ifThemedScrollbars(`
 			&::-webkit-scrollbar,
 			&::-webkit-scrollbar-track {
 				background-color: inherit;
@@ -145,6 +151,7 @@ export function getCoreBaseStyles({ coreStyles }: { theme: ExpressiveCodeTheme; 
 			&::-webkit-scrollbar-thumb:hover {
 				background-color: ${coreStyles.scrollbarThumbHoverColor};
 			}
+			`)}
 		}
 
 		/* Code lines */

--- a/packages/@expressive-code/core/src/common/engine.ts
+++ b/packages/@expressive-code/core/src/common/engine.ts
@@ -19,6 +19,24 @@ export interface ExpressiveCodeEngineConfig {
 	 */
 	defaultLocale?: string | undefined
 	/**
+	 * Whether the theme is allowed to style the scrollbars. Defaults to `true`.
+	 *
+	 * If set to `false`, scrollbars will be rendered using the browser's default style.
+	 *
+	 * Note that you can override the individual scrollbar colors defined by the theme
+	 * using the `styleOverrides` option.
+	 */
+	useThemedScrollbars?: boolean | undefined
+	/**
+	 * Whether the theme is allowed to style selected text. Defaults to `true`.
+	 *
+	 * If set to `false`, selected text will be rendered using the browser's default style.
+	 *
+	 * Note that you can override the individual selection colors defined by the theme
+	 * using the `styleOverrides` option.
+	 */
+	useThemedSelectionColors?: boolean | undefined
+	/**
 	 * An optional set of style overrides that can be used to customize the appearance of
 	 * the rendered code blocks without having to write custom CSS. You can customize core
 	 * colors, fonts, paddings and more.
@@ -43,6 +61,8 @@ export class ExpressiveCodeEngine {
 	constructor(config: ExpressiveCodeEngineConfig) {
 		this.theme = config.theme || new ExpressiveCodeTheme(githubDark)
 		this.defaultLocale = config.defaultLocale || 'en-US'
+		this.useThemedScrollbars = config.useThemedScrollbars ?? true
+		this.useThemedSelectionColors = config.useThemedSelectionColors ?? true
 		this.styleOverrides = {
 			...config.styleOverrides,
 		}
@@ -93,6 +113,8 @@ export class ExpressiveCodeEngine {
 			styles: getCoreBaseStyles({
 				theme: this.theme,
 				coreStyles: this.coreStyles,
+				useThemedScrollbars: this.useThemedScrollbars,
+				useThemedSelectionColors: this.useThemedSelectionColors,
 			}),
 		})
 		// Add plugin base styles
@@ -139,6 +161,8 @@ export class ExpressiveCodeEngine {
 
 	readonly theme: ExpressiveCodeTheme
 	readonly defaultLocale: string
+	readonly useThemedScrollbars: boolean
+	readonly useThemedSelectionColors: boolean
 	readonly styleOverrides: Partial<typeof coreStyleSettings.defaultSettings>
 	readonly coreStyles: ResolvedCoreStyles
 	readonly plugins: readonly ExpressiveCodePlugin[]

--- a/packages/@expressive-code/plugin-frames/README.md
+++ b/packages/@expressive-code/plugin-frames/README.md
@@ -88,17 +88,21 @@ console.log('Hello World!')
 
 When using this plugin through higher-level integration packages, you can configure it by passing options to the higher-level package.
 
-As it's most likely that you are using `remark-expressive-code`, here are configuration examples for some popular site generators:
+Here are configuration examples for some popular site generators:
 
 ### Astro configuration example
+
+We assume that you're using our Astro integration [`astro-expressive-code`](https://www.npmjs.com/package/astro-expressive-code).
+
+In your Astro config file, you can pass options to the frames plugin like this:
 
 ```js
 // astro.config.mjs
 import { defineConfig } from 'astro/config'
-import remarkExpressiveCode from 'remark-expressive-code'
+import astroExpressiveCode from 'astro-expressive-code'
 
-/** @type {import('remark-expressive-code').RemarkExpressiveCodeOptions} */
-const remarkExpressiveCodeOptions = {
+/** @type {import('astro-expressive-code').AstroExpressiveCodeOptions} */
+const astroExpressiveCodeOptions = {
   // This is where you can pass your plugin options
   frames: {
     styleOverrides: {
@@ -109,13 +113,9 @@ const remarkExpressiveCodeOptions = {
 }
 
 export default defineConfig({
-  markdown: {
-    remarkPlugins: [
-      // The nested array structure is required to pass options
-      // to a remark plugin
-      [remarkExpressiveCode, remarkExpressiveCodeOptions],
-    ],
-  },
+  integrations: [
+    astroExpressiveCode(astroExpressiveCodeOptions),
+  ],
 })
 ```
 

--- a/packages/@expressive-code/plugin-shiki/README.md
+++ b/packages/@expressive-code/plugin-shiki/README.md
@@ -50,17 +50,21 @@ The full list of languages can be found in the [Shiki documentation](https://git
 
 This plugin does not have any configuration options. It automatically uses the current theme of Expressive Code, which you can select using its `theme` configuration option.
 
-As it's most likely that you are using `remark-expressive-code`, here are configuration examples on how to select a theme in some popular site generators:
+Here are configuration examples on how to select a theme in some popular site generators:
 
 ### Astro configuration example
+
+We assume that you're using our Astro integration [`astro-expressive-code`](https://www.npmjs.com/package/astro-expressive-code).
+
+In your Astro config file, you can pass options to the plugin like this:
 
 ```js
 // astro.config.mjs
 import { defineConfig } from 'astro/config'
-import remarkExpressiveCode from 'remark-expressive-code'
+import astroExpressiveCode from 'astro-expressive-code'
 
-/** @type {import('remark-expressive-code').RemarkExpressiveCodeOptions} */
-const remarkExpressiveCodeOptions = {
+/** @type {import('astro-expressive-code').AstroExpressiveCodeOptions} */
+const astroExpressiveCodeOptions = {
   // You can set this to any of the themes bundled with Shiki,
   // specify a path to JSON theme file, or pass an instance
   // of the `ExpressiveCodeTheme` class here:
@@ -68,13 +72,9 @@ const remarkExpressiveCodeOptions = {
 }
 
 export default defineConfig({
-  markdown: {
-    remarkPlugins: [
-      // The nested array structure is required to pass options
-      // to a remark plugin
-      [remarkExpressiveCode, remarkExpressiveCodeOptions],
-    ],
-  },
+  integrations: [
+    astroExpressiveCode(astroExpressiveCodeOptions),
+  ],
 })
 ```
 

--- a/packages/@expressive-code/plugin-text-markers/README.md
+++ b/packages/@expressive-code/plugin-text-markers/README.md
@@ -122,17 +122,21 @@ You can also combine many different markers in a single code block:
 
 When using this plugin through higher-level integration packages, you can configure it by passing options to the higher-level package.
 
-As it's most likely that you are using `remark-expressive-code`, here are configuration examples for some popular site generators:
+Here are configuration examples for some popular site generators:
 
 ### Astro configuration example
+
+We assume that you're using our Astro integration [`astro-expressive-code`](https://www.npmjs.com/package/astro-expressive-code).
+
+In your Astro config file, you can pass options to the plugin like this:
 
 ```js
 // astro.config.mjs
 import { defineConfig } from 'astro/config'
-import remarkExpressiveCode from 'remark-expressive-code'
+import astroExpressiveCode from 'astro-expressive-code'
 
-/** @type {import('remark-expressive-code').RemarkExpressiveCodeOptions} */
-const remarkExpressiveCodeOptions = {
+/** @type {import('astro-expressive-code').AstroExpressiveCodeOptions} */
+const astroExpressiveCodeOptions = {
   // This is where you can pass your plugin options
   textMarkers: {
     styleOverrides: {
@@ -145,13 +149,9 @@ const remarkExpressiveCodeOptions = {
 }
 
 export default defineConfig({
-  markdown: {
-    remarkPlugins: [
-      // The nested array structure is required to pass options
-      // to a remark plugin
-      [remarkExpressiveCode, remarkExpressiveCodeOptions],
-    ],
-  },
+  integrations: [
+    astroExpressiveCode(astroExpressiveCodeOptions),
+  ],
 })
 ```
 

--- a/packages/astro-expressive-code/README.md
+++ b/packages/astro-expressive-code/README.md
@@ -10,6 +10,8 @@
 - [Usage in markdown / MDX documents](#usage-in-markdown--mdx-documents)
 - [Configuration](#configuration)
   - [`theme`](#theme)
+  - [`useThemedScrollbars`](#usethemedscrollbars)
+  - [`useThemedSelectionColors`](#usethemedselectioncolors)
   - [`styleOverrides`](#styleoverrides)
   - [`plugins`](#plugins)
   - [`shiki`](#shiki)
@@ -185,6 +187,28 @@ The following options are available:
   You can pass the name of any theme bundled with Shiki: `dark-plus`, `dracula-soft`, `dracula`, `github-dark-dimmed`, `github-dark`, `github-light`, `hc_light`, `light-plus`, `material-theme-darker`, `material-theme-lighter`, `material-theme-ocean`, `material-theme-palenight`, `material-theme`, `min-dark`, `min-light`, `monokai`, `nord`, `one-dark-pro`, `poimandres`, `rose-pine-dawn`, `rose-pine-moon`, `rose-pine`, `slack-dark`, `slack-ochin`, `solarized-dark`, `solarized-light`, `vitesse-dark`, `vitesse-light`
 
   You can also load a custom theme. See [`ExpressiveCodeTheme`](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/core/README.md#expressivecodetheme) for more information.
+
+### `useThemedScrollbars`
+
+- Type: `boolean`
+- Default: `true`
+
+- Whether the theme is allowed to style the scrollbars.
+
+  If set to `false`, scrollbars will be rendered using the browser's default style.
+
+  Note that you can override the individual scrollbar colors defined by the theme using the `styleOverrides` option.
+
+### `useThemedSelectionColors`
+
+- Type: `boolean`
+- Default: `true`
+
+- Whether the theme is allowed to style selected text.
+
+  If set to `false`, selected text will be rendered using the browser's default style.
+
+  Note that you can override the individual selection colors defined by the theme using the `styleOverrides` option.
 
 ### `styleOverrides`
 

--- a/packages/expressive-code/README.md
+++ b/packages/expressive-code/README.md
@@ -26,7 +26,7 @@ Included packages:
 
 Using this package directly is **only recommended for advanced use cases**, e.g. to create integrations of Expressive Code into other tools and frameworks.
 
-If you just want to render code blocks on your website, you should use one of the higher-level packages instead, e.g. `remark-expressive-code` for code blocks in markdown / MDX documents.
+If you just want to render code blocks on your website, you should use one of the higher-level packages instead, e.g. [`astro-expressive-code`](https://www.npmjs.com/package/astro-expressive-code) or [`remark-expressive-code`](https://www.npmjs.com/package/remark-expressive-code) for code blocks in markdown / MDX documents.
 
 ## Installation
 

--- a/packages/remark-expressive-code/README.md
+++ b/packages/remark-expressive-code/README.md
@@ -12,6 +12,8 @@
 - [Usage in markdown / MDX documents](#usage-in-markdown--mdx-documents)
 - [Configuration](#configuration)
   - [`theme`](#theme)
+  - [`useThemedScrollbars`](#usethemedscrollbars)
+  - [`useThemedSelectionColors`](#usethemedselectioncolors)
   - [`styleOverrides`](#styleoverrides)
   - [`plugins`](#plugins)
   - [`shiki`](#shiki)
@@ -54,27 +56,7 @@ You can see some examples for popular site generators below. If your site genera
 
 ### Astro example
 
-```js
-// astro.config.mjs
-import { defineConfig } from 'astro/config'
-import remarkExpressiveCode from 'remark-expressive-code'
-
-/** @type {import('remark-expressive-code').RemarkExpressiveCodeOptions} */
-const remarkExpressiveCodeOptions = {
-  // You can add configuration options here,
-  // see the API section for more information
-}
-
-export default defineConfig({
-  markdown: {
-    remarkPlugins: [
-      // The nested array structure below is used
-      // to pass options to the remark plugin
-      [remarkExpressiveCode, remarkExpressiveCodeOptions],
-    ],
-  },
-})
-```
+We recommend using our dedicated Astro integration instead: [`astro-expressive-code`](https://www.npmjs.com/package/astro-expressive-code)
 
 ### Next.js example using `@next/mdx`
 
@@ -229,6 +211,28 @@ The following options are available:
   You can pass the name of any theme bundled with Shiki: `dark-plus`, `dracula-soft`, `dracula`, `github-dark-dimmed`, `github-dark`, `github-light`, `hc_light`, `light-plus`, `material-theme-darker`, `material-theme-lighter`, `material-theme-ocean`, `material-theme-palenight`, `material-theme`, `min-dark`, `min-light`, `monokai`, `nord`, `one-dark-pro`, `poimandres`, `rose-pine-dawn`, `rose-pine-moon`, `rose-pine`, `slack-dark`, `slack-ochin`, `solarized-dark`, `solarized-light`, `vitesse-dark`, `vitesse-light`
 
   You can also load a custom theme. See [`ExpressiveCodeTheme`](https://github.com/expressive-code/expressive-code/blob/main/packages/%40expressive-code/core/README.md#expressivecodetheme) for more information.
+
+### `useThemedScrollbars`
+
+- Type: `boolean`
+- Default: `true`
+
+- Whether the theme is allowed to style the scrollbars.
+
+  If set to `false`, scrollbars will be rendered using the browser's default style.
+
+  Note that you can override the individual scrollbar colors defined by the theme using the `styleOverrides` option.
+
+### `useThemedSelectionColors`
+
+- Type: `boolean`
+- Default: `true`
+
+- Whether the theme is allowed to style selected text.
+
+  If set to `false`, selected text will be rendered using the browser's default style.
+
+  Note that you can override the individual selection colors defined by the theme using the `styleOverrides` option.
 
 ### `styleOverrides`
 

--- a/packages/remark-expressive-code/test/remark.test.ts
+++ b/packages/remark-expressive-code/test/remark.test.ts
@@ -7,6 +7,12 @@ import toHtml from 'rehype-stringify'
 import remarkExpressiveCode, { RemarkExpressiveCodeOptions } from '../src'
 import { sampleCodeHtmlRegExp, sampleCodeMarkdown } from './utils'
 
+const regexCodeBg = /.ec-\w+? pre{(?:[^}]*?;)*background:(.*?)[;}]/
+const regexCodeColor = /.ec-\w+? pre\s*>\s*code{(?:[^}]*?;)*color:(.*?)[;}]/
+const regexCodeSelectionBg = /.ec-\w+? pre\s+::selection{(?:[^}]*?;)*background:(.*?)[;}]/
+const regexScrollbarThumbColor = /.ec-\w+? pre::-webkit-scrollbar-thumb{(?:[^}]*?;)*background-color:(.*?)[;}]/
+const regexScrollbarHoverColor = /.ec-\w+? pre::-webkit-scrollbar-thumb:hover{(?:[^}]*?;)*background-color:(.*?)[;}]/
+
 describe('Usage inside unified/remark', () => {
 	test('Works without any options', async () => {
 		const processor = createRemarkProcessor()
@@ -27,11 +33,84 @@ describe('Usage inside unified/remark', () => {
 				const processor = createRemarkProcessor({ theme })
 				const result = await processor.process(sampleCodeMarkdown)
 				const html = result.value.toString()
-				const actualBgColor = html.match(/.ec-\w+? pre{(?:[^}]*?;)*background:(.*?)[;}]/)?.[1]
-				const actualTextColor = html.match(/.ec-\w+? pre\s*>\s*code{(?:[^}]*?;)*color:(.*?)[;}]/)?.[1]
+				const actualBgColor = html.match(regexCodeBg)?.[1]
+				const actualTextColor = html.match(regexCodeColor)?.[1]
 				expect(html).toMatch(sampleCodeHtmlRegExp)
-				expect(actualBgColor).toMatch(bgColor)
-				expect(actualTextColor).toMatch(textColor)
+				expect(actualBgColor).toEqual(bgColor)
+				expect(actualTextColor).toEqual(textColor)
+			})
+		)
+	})
+	test('Allows the theme to customize the scrollbar by default', async () => {
+		const testCases: {
+			theme: RemarkExpressiveCodeOptions['theme']
+			thumbColor: string
+			hoverColor: string
+		}[] = [
+			{ theme: 'light-plus', thumbColor: '#64646466', hoverColor: '#646464b2' },
+			{ theme: 'material-theme', thumbColor: '#eeffff20', hoverColor: '#eeffff4b' },
+		]
+		await Promise.all(
+			testCases.map(async ({ theme, thumbColor, hoverColor }) => {
+				const processor = createRemarkProcessor({ theme })
+				const result = await processor.process(sampleCodeMarkdown)
+				const html = result.value.toString()
+				const actualThumbColor = html.match(regexScrollbarThumbColor)?.[1]
+				const actualHoverColor = html.match(regexScrollbarHoverColor)?.[1]
+				expect(html).toMatch(sampleCodeHtmlRegExp)
+				expect(actualThumbColor).toEqual(thumbColor)
+				expect(actualHoverColor).toEqual(hoverColor)
+			})
+		)
+	})
+	test('Does not customize the scrollbar if `useThemedScrollbars` is false', async () => {
+		const testCases: {
+			theme: RemarkExpressiveCodeOptions['theme']
+		}[] = [{ theme: 'light-plus' }, { theme: 'material-theme' }]
+		await Promise.all(
+			testCases.map(async ({ theme }) => {
+				const processor = createRemarkProcessor({ theme, useThemedScrollbars: false })
+				const result = await processor.process(sampleCodeMarkdown)
+				const html = result.value.toString()
+				const actualThumbColor = html.match(regexScrollbarThumbColor)?.[1]
+				const actualHoverColor = html.match(regexScrollbarHoverColor)?.[1]
+				expect(html).toMatch(sampleCodeHtmlRegExp)
+				expect(actualThumbColor).toBeUndefined()
+				expect(actualHoverColor).toBeUndefined()
+			})
+		)
+	})
+	test('Allows the theme to customize selection colors by default', async () => {
+		const testCases: {
+			theme: RemarkExpressiveCodeOptions['theme']
+			codeSelectionBg: string
+		}[] = [
+			{ theme: 'light-plus', codeSelectionBg: '#add6ff' },
+			{ theme: 'material-theme', codeSelectionBg: '#80cbc420' },
+		]
+		await Promise.all(
+			testCases.map(async ({ theme, codeSelectionBg }) => {
+				const processor = createRemarkProcessor({ theme })
+				const result = await processor.process(sampleCodeMarkdown)
+				const html = result.value.toString()
+				const actualBg = html.match(regexCodeSelectionBg)?.[1]
+				expect(html).toMatch(sampleCodeHtmlRegExp)
+				expect(actualBg).toEqual(codeSelectionBg)
+			})
+		)
+	})
+	test('Does not customize selection colors if `useThemedSelectionColors` is false', async () => {
+		const testCases: {
+			theme: RemarkExpressiveCodeOptions['theme']
+		}[] = [{ theme: 'light-plus' }, { theme: 'material-theme' }]
+		await Promise.all(
+			testCases.map(async ({ theme }) => {
+				const processor = createRemarkProcessor({ theme, useThemedSelectionColors: false })
+				const result = await processor.process(sampleCodeMarkdown)
+				const html = result.value.toString()
+				const actualBg = html.match(regexCodeSelectionBg)?.[1]
+				expect(html).toMatch(sampleCodeHtmlRegExp)
+				expect(actualBg).toBeUndefined()
 			})
 		)
 	})


### PR DESCRIPTION
Addresses #18 by adding the config options `useThemedScrollbars` and `useThemedSelectionColors`.

Both options default to `true`. Set any of them to `false` to prevent themes from customizing their appearance and render them using the browser's default style.
