### PR TITLE
Support ansi highlighting

### DIFF
--- a/.changeset/empty-bananas-wait.md
+++ b/.changeset/empty-bananas-wait.md
@@ -1,0 +1,6 @@
+---
+'@expressive-code/plugin-frames': minor
+'@expressive-code/plugin-shiki': minor
+---
+
+Add support for ansi formatting for codeblocks with language set to `ansi`

--- a/packages/@expressive-code/plugin-frames/src/utils.ts
+++ b/packages/@expressive-code/plugin-frames/src/utils.ts
@@ -23,7 +23,7 @@ export function frameTypeFromString(input: string) {
 
 export const LanguageGroups = {
 	code: ['astro', 'cjs', 'htm', 'html', 'js', 'jsx', 'mjs', 'svelte', 'ts', 'tsx', 'typescript', 'vb', 'vue', 'vue-html'],
-	terminal: ['bash', 'bat', 'batch', 'cmd', 'console', 'powershell', 'ps', 'ps1', 'psd1', 'psm1', 'sh', 'shell', 'shellscript', 'shellsession', 'zsh'],
+	terminal: ['ansi', 'bash', 'bat', 'batch', 'cmd', 'console', 'powershell', 'ps', 'ps1', 'psd1', 'psm1', 'sh', 'shell', 'shellscript', 'shellsession', 'zsh'],
 	data: ['csv', 'env', 'ini', 'json', 'toml', 'xml', 'yaml', 'yml'],
 	styles: ['css', 'less', 'sass', 'scss', 'styl', 'stylus', 'xsl'],
 	textContent: ['markdown', 'md', 'mdx'],

--- a/packages/@expressive-code/plugin-shiki/src/index.ts
+++ b/packages/@expressive-code/plugin-shiki/src/index.ts
@@ -44,8 +44,18 @@ export function pluginShiki(): ExpressiveCodePlugin {
 				}
 
 				// Run Shiki on the code (without explanations to improve performance)
-				const tokenLines = highlighter.codeToThemedTokens(code, codeBlock.language, theme.name, { includeExplanation: false })
+				const tokenLines =
+					codeBlock.language === 'ansi'
+						? highlighter.ansiToThemedTokens(code, theme.name)
+						: highlighter.codeToThemedTokens(code, codeBlock.language, theme.name, { includeExplanation: false })
+
 				tokenLines.forEach((line, lineIndex) => {
+					if (codeBlock.language === 'ansi') {
+						// Update line to trimmed version without sequence characters before adding styles
+						const trimmedLine = line.map((token) => token.content).join('')
+						codeLines[lineIndex].editText(undefined, undefined, trimmedLine)
+					}
+
 					let charIndex = 0
 					line.forEach((token) => {
 						const tokenLength = token.content.length

--- a/packages/@expressive-code/plugin-shiki/test/rendering.test.ts
+++ b/packages/@expressive-code/plugin-shiki/test/rendering.test.ts
@@ -25,6 +25,20 @@ npm create astro@latest -- --template <example-name>
 npm create astro@latest -- --template <github-username>/<github-repo>
 `.trim()
 
+const ansiTestCode = `
+[95mRunning tests from 'C:\\Git\\Pester\\expressiveCodeAnsiDemo.tests.ps1'[0m
+[92mDescribing Expressive Code[0m
+[96m Context Testing ANSI[0m
+[32m   [+] Success[0m[90m 3ms (1ms|2ms)[0m
+[91m   [-] Failure[0m[90m 2ms (2ms|0ms)[0m
+[91m    Expected 2, but got 1.[0m
+[97mTests completed in 47ms[0m
+[97mTests Passed: 1 [0m[91mFailed: 1 [0m[90mSkipped: 0 [0m[37m[0m[90mNotRun: 0[0m
+`.trim()
+
+// eslint-disable-next-line no-control-regex
+const ansiEscapeCode = /\u001b\[\d+m/gmu
+
 describe('Renders syntax highlighting', () => {
 	const themes: (ExpressiveCodeTheme | undefined)[] = testThemeNames.map(loadTestTheme)
 	themes.unshift(undefined)
@@ -60,6 +74,27 @@ describe('Renders syntax highlighting', () => {
 					blockValidationFn: ({ renderedGroupAst }) => {
 						const html = toHtml(renderedGroupAst)
 						expect(html).toContain('example-name')
+					},
+				}),
+			})
+		},
+		{ timeout: 5 * 1000 }
+	)
+
+	test(
+		'Supports ansi',
+		async ({ meta: { name: testName } }) => {
+			await renderAndOutputHtmlSnapshot({
+				testName,
+				testBaseDir: __dirname,
+				fixtures: buildThemeFixtures(themes, {
+					code: ansiTestCode,
+					language: 'ansi',
+					meta: '',
+					plugins: [pluginShiki()],
+					blockValidationFn: ({ renderedGroupAst }) => {
+						const html = toHtml(renderedGroupAst)
+						expect(html).not.toMatch(ansiEscapeCode)
 					},
 				}),
 			})


### PR DESCRIPTION
Implements Shiki's ANSI-support for codeblocks using language `ansi`. This enables colored output, typically for console applications.

Fix #24 