### PR TITLE
Astro expressive code component

### DIFF
--- a/packages/astro-expressive-code/src/components/Code.astro
+++ b/packages/astro-expressive-code/src/components/Code.astro
@@ -1,0 +1,90 @@
+---
+import type * as shiki from 'shiki';
+import { renderToHtml } from 'shiki';
+import { getHighlighter } from './Shiki.js';
+
+export interface Props {
+	/** The code to highlight. Required. */
+	code: string;
+	/**
+	 * The language of your code.
+	 * Supports all languages listed here: https://github.com/shikijs/shiki/blob/main/docs/languages.md#all-languages
+	 * Instructions for loading a custom language: https://github.com/shikijs/shiki/blob/main/docs/languages.md#supporting-your-own-languages-with-shiki
+	 *
+	 * @default "plaintext"
+	 */
+	lang?: shiki.Lang | shiki.ILanguageRegistration;
+	/**
+	 * The styling theme.
+	 * Supports all themes listed here: https://github.com/shikijs/shiki/blob/main/docs/themes.md#all-themes
+	 * Instructions for loading a custom theme: https://github.com/shikijs/shiki/blob/main/docs/themes.md#loading-theme
+	 *
+	 * @default "github-dark"
+	 */
+	theme?: shiki.IThemeRegistration;
+	/**
+	 * Enable word wrapping.
+	 *  - true: enabled.
+	 *  - false: disabled.
+	 *  - null: All overflow styling removed. Code will overflow the element by default.
+	 *
+	 * @default false
+	 */
+	wrap?: boolean | null;
+	/**
+	 * Generate inline code element only, without the pre element wrapper.
+	 *
+	 * @default false
+	 */
+	inline?: boolean;
+}
+
+const {
+	code,
+	lang = 'plaintext',
+	theme = 'github-dark',
+	wrap = false,
+	inline = false,
+} = Astro.props;
+
+// 1. Get the shiki syntax highlighter
+const highlighter = await getHighlighter({
+	theme,
+	// Load custom lang if passed an object, otherwise load the default
+	langs: typeof lang !== 'string' ? [lang] : undefined,
+});
+
+// 2. Turn code into shiki theme tokens
+const tokens = highlighter.codeToThemedTokens(code, typeof lang === 'string' ? lang : lang.id);
+
+// 3. Get shiki theme object
+const _theme = highlighter.getTheme();
+
+// 4. Render the theme tokens as html
+const html = renderToHtml(tokens, {
+	themeName: _theme.name,
+	fg: _theme.fg,
+	bg: _theme.bg,
+	elements: {
+		pre({ className, style, children }) {
+			// Swap to `code` tag if inline
+			const tag = inline ? 'code' : 'pre';
+			// Replace "shiki" class naming with "astro-code"
+			className = className.replace(/shiki/g, 'astro-code');
+			// Handle code wrapping
+			// if wrap=null, do nothing.
+			if (wrap === false) {
+				style += '; overflow-x: auto;"';
+			} else if (wrap === true) {
+				style += '; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word;"';
+			}
+			return `<${tag} class="${className}" style="${style}" tabindex="0">${children}</${tag}>`;
+		},
+		code({ children }) {
+			return inline ? children : `<code>${children}</code>`;
+		},
+	},
+});
+---
+
+<Fragment set:html={html} />

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -2,6 +2,8 @@ import type { AstroIntegration } from 'astro'
 import type { RemarkExpressiveCodeOptions } from 'remark-expressive-code'
 import remarkExpressiveCode, { createRenderer } from 'remark-expressive-code'
 
+export { default as Code } from './components/Code.astro'
+
 export * from 'remark-expressive-code'
 
 export type AstroExpressiveCodeOptions = RemarkExpressiveCodeOptions

--- a/packages/astro-expressive-code/test/fixtures/astro/src/pages/code-component.astro
+++ b/packages/astro-expressive-code/test/fixtures/astro/src/pages/code-component.astro
@@ -1,0 +1,10 @@
+---
+import { Code } from 'astro-expressive-code'
+
+const JS = `
+// test.js
+const a = 1
+`
+---
+
+<Code code={JS} />

--- a/packages/astro-expressive-code/test/integration.test.ts
+++ b/packages/astro-expressive-code/test/integration.test.ts
@@ -23,6 +23,10 @@ describe('Integration into an Astro project', () => {
 	test('MDX files', () => {
 		expect(fixture?.readFile('mdx-page/index.html')).toMatch(sampleCodeHtmlRegExp)
 	})
+
+	test('Code component', () => {
+		expect(fixture?.readFile('code-component/index.html')).toMatch(sampleCodeHtmlRegExp)
+	})
 })
 
 async function buildFixture({ fixtureDir, buildCommand, buildArgs, outputDir }: { fixtureDir: string; buildCommand: string; buildArgs?: string[] | undefined; outputDir: string }) {

--- a/packages/astro-expressive-code/tsconfig.json
+++ b/packages/astro-expressive-code/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "jsx": "react-jsx",
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,6 +13,7 @@
     "moduleResolution": "node",
     "module": "ESNext",
     "target": "ESNext",
+    "jsx": "react-jsx",
     "paths": {
       "@expressive-code/core": ["./packages/@expressive-code/core/src"],
       "@expressive-code/plugin-frames": ["./packages/@expressive-code/plugin-frames/src"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,6 @@
     "moduleResolution": "node",
     "module": "ESNext",
     "target": "ESNext",
-    "jsx": "react-jsx",
     "paths": {
       "@expressive-code/core": ["./packages/@expressive-code/core/src"],
       "@expressive-code/plugin-frames": ["./packages/@expressive-code/plugin-frames/src"],


### PR DESCRIPTION
**draft**

Drop-In replacement for Astro's `<Code />` component. Usage:

```astro
---
import { Code } from 'astro-expressive-code'

const JS = `
// test.js
const a = 1
`
---

<Code code={JS} /> <!-- renders as expressive code -->
```