### PR TITLE
Support CSS variable colour as terminal dots foreground

### DIFF
--- a/.changeset/olive-bikes-shout.md
+++ b/.changeset/olive-bikes-shout.md
@@ -1,0 +1,5 @@
+---
+'@expressive-code/plugin-frames': patch
+---
+
+Support CSS variable colour as terminal dots foreground

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -163,6 +163,7 @@ export function getFramesBaseStyles(theme: ExpressiveCodeTheme, coreStyles: Reso
 
 				/* Display three dots at the left side of the header */
 				&::before {
+					content: '';
 					background-color: ${framesStyles.terminalTitlebarDotsForeground};
 					-webkit-mask-image: ${terminalTitlebarDots};
 					mask-image: ${terminalTitlebarDots};

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -36,9 +36,8 @@ export function getFramesBaseStyles(theme: ExpressiveCodeTheme, coreStyles: Reso
 		styleOverrides: options.styleOverrides,
 	})
 
-	const dotsColor = toRgbaString(framesStyles.terminalTitlebarDotsForeground)
 	const dotsSvg = [
-		`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 16' preserveAspectRatio='xMidYMid meet' fill='${dotsColor}'>`,
+		`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 16' preserveAspectRatio='xMidYMid meet'>`,
 		`<circle cx='8' cy='8' r='8'/>`,
 		`<circle cx='30' cy='8' r='8'/>`,
 		`<circle cx='52' cy='8' r='8'/>`,
@@ -164,7 +163,9 @@ export function getFramesBaseStyles(theme: ExpressiveCodeTheme, coreStyles: Reso
 
 				/* Display three dots at the left side of the header */
 				&::before {
-					content: ${terminalTitlebarDots};
+					background-color: ${framesStyles.terminalTitlebarDotsForeground};
+					-webkit-mask-image: ${terminalTitlebarDots};
+					mask-image: ${terminalTitlebarDots};
 					position: absolute;
 					left: ${coreStyles.uiPaddingInline};
 					width: 2.1rem;

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -166,10 +166,13 @@ export function getFramesBaseStyles(theme: ExpressiveCodeTheme, coreStyles: Reso
 					content: '';
 					background-color: ${framesStyles.terminalTitlebarDotsForeground};
 					-webkit-mask-image: ${terminalTitlebarDots};
+					-webkit-mask-repeat: no-repeat;
 					mask-image: ${terminalTitlebarDots};
+					mask-repeat: no-repeat;
 					position: absolute;
 					left: ${coreStyles.uiPaddingInline};
 					width: 2.1rem;
+					height: ${(2.1 / 60) * 16}rem;
 					line-height: 0;
 				}
 				/* Display a border below the header */


### PR DESCRIPTION
This PR tweaks the styles for the three dots shown top left in terminal frames in the frames plugin. Instead of using an SVG for the `content` of the pseudo-element, it uses the SVG as a `mask-image` instead. This lets us set the colour with a CSS custom property (or other complex value such as a gradient), which is not permitted in data URL images as they are treated as external images (which don’t have access to document-scope values such as custom properties or keywords like `currentColor`.

A user could now set a style override like this and have it work:
```js
terminalTitlebarDotsForeground: 'var(--my-accent-color)',
```

Or even to mimic macOS style close/minimise/zoom colours:
```js
terminalTitlebarDotsForeground: 'linear-gradient(to right, red 33%, yellow 33%, yellow 66%, green 66%)',
```