### PR TITLE
Add `removeCommentsWhenCopyingTerminalFrames`

### DIFF
--- a/.changeset/good-suns-hug.md
+++ b/.changeset/good-suns-hug.md
@@ -1,0 +1,12 @@
+---
+'@expressive-code/plugin-frames': minor
+'astro-expressive-code': minor
+'expressive-code': minor
+'remark-expressive-code': minor
+---
+
+Add `removeCommentsWhenCopyingTerminalFrames` config option to `plugin-frames`. Thanks @AkashRajpurohit!
+
+If `true` (which is the default), the "Copy to clipboard" button of terminal window frames will remove comment lines starting with `#` from the copied text.
+
+This is useful to reduce the copied text to the actual commands users need to run, instead of also copying explanatory comments or instructions.

--- a/packages/@expressive-code/plugin-frames/README.md
+++ b/packages/@expressive-code/plugin-frames/README.md
@@ -187,6 +187,16 @@ You can pass the following options to the plugin:
 
   If `true` (which is the default), and no title was found in the code block's meta string, the plugin will try to find and extract a comment line containing the code block file name from the first 4 lines of the code.
 
+- `showCopyToClipboardButton: boolean`
+
+  If `true` (which is the default), a "Copy to clipboard" button will be shown for each code block.
+
+- `removeCommentsWhenCopyingTerminalFrames: boolean`
+
+  If `true` (which is the default), the "Copy to clipboard" button of terminal window frames will remove comment lines starting with `#` from the copied text.
+  
+  This is useful to reduce the copied text to the actual commands users need to run, instead of also copying explanatory comments or instructions.
+
 - `styleOverrides`
 
   Allows overriding the plugin's default styles using an object with named properties.

--- a/packages/@expressive-code/plugin-frames/test/copy-button.test.ts
+++ b/packages/@expressive-code/plugin-frames/test/copy-button.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import { Parent } from 'hast-util-to-html/lib/types'
+import { select } from 'hast-util-select'
+import { ExpressiveCodeTheme } from '@expressive-code/core'
+import { renderAndOutputHtmlSnapshot, testThemeNames, loadTestTheme, buildThemeFixtures } from '@internal/test-utils'
+import { pluginFrames } from '../src'
+
+const exampleTerminalCode = `
+# Install dev dependencies
+pnpm i --save-dev expressive-code some-other-package yet-another-package
+
+# And a regular one
+pnpm i one-more-package
+`.trim()
+
+const exampleTerminalCodeWithoutComments = `
+pnpm i --save-dev expressive-code some-other-package yet-another-package
+pnpm i one-more-package
+`.trim()
+
+describe('Allows removing comments from terminal window frames', () => {
+	const themes: (ExpressiveCodeTheme | undefined)[] = testThemeNames.map(loadTestTheme)
+	themes.unshift(undefined)
+
+	test('Terminal comments are removed by default', async ({ meta: { name: testName } }) => {
+		await renderAndOutputHtmlSnapshot({
+			testName,
+			testBaseDir: __dirname,
+			fixtures: buildThemeFixtures(themes, {
+				code: exampleTerminalCode,
+				language: 'shell',
+				plugins: [pluginFrames()],
+				blockValidationFn: ({ renderedGroupAst }) => {
+					validateBlockAst({
+						renderedGroupAst,
+						codeToCopy: exampleTerminalCodeWithoutComments,
+					})
+				},
+			}),
+		})
+	})
+	test('Terminal comments can be retained through options', async ({ meta: { name: testName } }) => {
+		await renderAndOutputHtmlSnapshot({
+			testName,
+			testBaseDir: __dirname,
+			fixtures: buildThemeFixtures(themes, {
+				code: exampleTerminalCode,
+				language: 'shell',
+				plugins: [pluginFrames({ removeCommentsWhenCopyingTerminalFrames: false })],
+				blockValidationFn: ({ renderedGroupAst }) => {
+					validateBlockAst({
+						renderedGroupAst,
+						codeToCopy: exampleTerminalCode,
+					})
+				},
+			}),
+		})
+	})
+	test('Comments are not removed from non-terminal frames', async ({ meta: { name: testName } }) => {
+		await renderAndOutputHtmlSnapshot({
+			testName,
+			testBaseDir: __dirname,
+			fixtures: buildThemeFixtures(themes, {
+				code: exampleTerminalCode,
+				language: 'md',
+				plugins: [pluginFrames()],
+				blockValidationFn: ({ renderedGroupAst }) => {
+					validateBlockAst({
+						renderedGroupAst,
+						codeToCopy: exampleTerminalCode,
+					})
+				},
+			}),
+		})
+	})
+})
+
+function validateBlockAst({ renderedGroupAst, codeToCopy }: { renderedGroupAst: Parent; codeToCopy: string }) {
+	// Expect the pre element to be followed by the copy button
+	const copyButton = select('pre + .copy button', renderedGroupAst)
+	expect(copyButton).toBeTruthy()
+
+	// Expect the copy button to contain a data attribute with the correct code to copy
+	const actualCode = copyButton?.properties?.dataCode?.toString().replace(/\u007f/g, '\n')
+	expect(actualCode).toBe(codeToCopy)
+}


### PR DESCRIPTION
Closes #41 by adding a new `removeCommentsWhenCopyingTerminalFrames` config option to `plugin-frames`. Thanks @AkashRajpurohit!

If `true` (which is the default), the "Copy to clipboard" button of terminal window frames will remove comment lines starting with `#` from the copied text.

This is useful to reduce the copied text to the actual commands users need to run, instead of also copying explanatory comments or instructions.
