### PR TITLE
Hide summary marker for collapsible section on Safari

### DIFF
--- a/.changeset/chatty-doors-float.md
+++ b/.changeset/chatty-doors-float.md
@@ -1,0 +1,5 @@
+---
+'@expressive-code/plugin-collapsible-sections': patch
+---
+
+Hide summary marker on Safari for collapsible section

--- a/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
+++ b/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
@@ -40,6 +40,11 @@ export function getCollapsibleSectionsBaseStyles(
 					height: 16px;
 				}
 
+				/* workaround - ::marker does not support content on safari */
+				&::-webkit-details-marker {
+					display: none;
+				}
+
 				svg {
 					vertical-align: text-bottom;
 					fill: currentColor;


### PR DESCRIPTION
Safari doesn't support `content` for `::marker` pseudo-element. See https://bugs.webkit.org/show_bug.cgi?id=204163

Workaround using non-standard pseudo-element.
Addresses comment: https://github.com/expressive-code/expressive-code/pull/50/files#r1299367415