### PR TITLE
Re-initialize copy to clipboard buttons after Astro view transitions

### DIFF
--- a/.changeset/slow-zoos-teach.md
+++ b/.changeset/slow-zoos-teach.md
@@ -1,0 +1,6 @@
+---
+'@expressive-code/plugin-frames': patch
+'astro-expressive-code': patch
+---
+
+Re-initialize copy to clipboard buttons after Astro view transitions.

--- a/packages/@expressive-code/plugin-frames/src/copy-js-module.ts
+++ b/packages/@expressive-code/plugin-frames/src/copy-js-module.ts
@@ -110,6 +110,8 @@ const attachHandlers = [
 		)
 	);
 	obs.observe(document.body, { childList: true, subtree: true });`,
+	// Also re-initialize all buttons after view transitions initiated by popular frameworks
+	`document.addEventListener('astro:page-load', () => initButtons(document));`,
 ]
 
 export const getCopyJsModule = (buttonSelector: string) => {


### PR DESCRIPTION
Fixes #70 by adding an event handler for Astro view transitions.