### PR TITLE
Temp disable `emitExternalStylesheet` due to a bug

### DIFF
--- a/.changeset/short-phones-tell.md
+++ b/.changeset/short-phones-tell.md
@@ -1,0 +1,7 @@
+---
+'astro-expressive-code': patch
+---
+
+Temporarily disable new `emitExternalStylesheet` option again due to a route resolution bug.
+
+Sadly, this bug didn't occur before actually publishing the package - it worked fine when linking the package locally. Insert sad trombone sound here.

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -7,6 +7,9 @@ export * from 'remark-expressive-code'
 
 export type AstroExpressiveCodeOptions = RemarkExpressiveCodeOptions & {
 	/**
+	 * **Note**: This option is currently not working due to a route resolution bug.
+	 * Will be fixed soon.
+	 *
 	 * Determines if the styles required to display code blocks should be emitted into a separate
 	 * CSS file rather than being inlined into the rendered HTML of the first code block per page.
 	 * The generated URL `_astro/ec.{hash}.css` includes a content hash and can be cached
@@ -37,8 +40,8 @@ export function astroExpressiveCode(options: AstroExpressiveCodeOptions = {}) {
 		name: 'astro-expressive-code',
 		hooks: {
 			'astro:config:setup': async (args: unknown) => {
-				const { config, updateConfig, injectRoute } = args as ConfigSetupHookArgs
-				const { emitExternalStylesheet = true, customCreateRenderer, plugins = [], ...rest } = options ?? {}
+				const { config, updateConfig, injectRoute, injectScript } = args as ConfigSetupHookArgs
+				const { /*emitExternalStylesheet = true,*/ customCreateRenderer, plugins = [], ...rest } = options ?? {}
 
 				// Validate Astro configuration
 				const ownPosition = config.integrations.findIndex((integration) => integration.name === 'astro-expressive-code')
@@ -100,19 +103,24 @@ export function astroExpressiveCode(options: AstroExpressiveCodeOptions = {}) {
 
 				// Unless disabled, move the base and theme styles from the inline renderer
 				// into an external CSS file that can be cached by browsers
-				if (emitExternalStylesheet) {
-					const combinedStyles = `${renderer.baseStyles}${renderer.themeStyles}`
-					hashedStyles.push(getHashedRouteWithContent(combinedStyles, '/_astro/ec.{hash}.css'))
-					renderer.baseStyles = ''
-					renderer.themeStyles = ''
-				}
+				// TODO: Restore new code again once I figured out how to make `injectRoute`
+				// actually find its entryPoint when imported from a non-local package
+				// if (emitExternalStylesheet) {
+				// 	const combinedStyles = `${renderer.baseStyles}${renderer.themeStyles}`
+				// 	hashedStyles.push(getHashedRouteWithContent(combinedStyles, '/_astro/ec.{hash}.css'))
+				// 	renderer.baseStyles = ''
+				// 	renderer.themeStyles = ''
+				// }
 
 				// Also move any JS modules into external files
 				// (this is always enabled because the alternative using `injectScript`
 				// does not allow omitting the scripts on pages without any code blocks)
 				const uniqueJsModules = [...new Set<string>(renderer.jsModules)]
 				renderer.jsModules = []
-				hashedScripts.push(...uniqueJsModules.map((moduleCode) => getHashedRouteWithContent(moduleCode, '/_astro/ec.{hash}.js')))
+				// TODO: Restore new code again once I figured out how to make `injectRoute`
+				// actually find its entryPoint when imported from a non-local package
+				uniqueJsModules.forEach((moduleCode) => injectScript('page', moduleCode))
+				// hashedScripts.push(...uniqueJsModules.map((moduleCode) => getHashedRouteWithContent(moduleCode, '/_astro/ec.{hash}.js')))
 
 				// Inject route handlers that provide access to the extracted styles & scripts
 				hashedStyles.forEach(([hashedRoute]) => {

--- a/packages/astro-expressive-code/test/integration.test.ts
+++ b/packages/astro-expressive-code/test/integration.test.ts
@@ -42,12 +42,12 @@ describe('Integration into Astro ^3.0.0', () => {
 		validateHtml(html)
 	})
 
-	test('Emits an external stylesheet file', () => {
+	test.skip('Emits an external stylesheet file', () => {
 		const files = fixture?.readDir('_astro') ?? []
 		expect(files.filter((fileName) => fileName.match(/^ec\..*?\.css$/))).toHaveLength(1)
 	})
 
-	test('Emits an external script file', () => {
+	test.skip('Emits an external script file', () => {
 		const files = fixture?.readDir('_astro') ?? []
 		expect(files.filter((fileName) => fileName.match(/^ec\..*?\.js$/))).toHaveLength(1)
 	})
@@ -75,18 +75,19 @@ describe('Integration into Astro ^3.5.0 with `emitExternalStylesheet: false`', (
 		validateHtml(html, { emitExternalStylesheet: false })
 	})
 
-	test('Emits no external stylesheet file due to `emitExternalStylesheet: false`', () => {
+	test.skip('Emits no external stylesheet file due to `emitExternalStylesheet: false`', () => {
 		const files = fixture?.readDir('_astro') ?? []
 		expect(files.filter((fileName) => fileName.match(/^ec\..*?\.css$/))).toHaveLength(0)
 	})
 
-	test('Emits an external script file', () => {
+	test.skip('Emits an external script file', () => {
 		const files = fixture?.readDir('_astro') ?? []
 		expect(files.filter((fileName) => fileName.match(/^ec\..*?\.js$/))).toHaveLength(1)
 	})
 })
 
 function validateHtml(html: string, options?: { emitExternalStylesheet?: boolean | undefined }) {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { emitExternalStylesheet = true } = options ?? {}
 
 	// Expect the HTML structure to match our regular expression
@@ -95,7 +96,8 @@ function validateHtml(html: string, options?: { emitExternalStylesheet?: boolean
 
 	// Depending on the `emitExternalStylesheet` option, expect the `styles` capture group
 	// to either contain an external stylesheet or an inline style element
-	expect(matches?.groups?.['styles']).toContain(emitExternalStylesheet ? '<link rel="stylesheet"' : '<style>')
+	// TODO: Restore this check
+	// expect(matches?.groups?.['styles']).toContain(emitExternalStylesheet ? '<link rel="stylesheet"' : '<style>')
 
 	// Collect all code blocks
 	const codeBlockClassNames = [...html.matchAll(/<div class="(expressive-code(?:| .*?))">/g)].map((match) => match[1])


### PR DESCRIPTION
Temporarily disable new `emitExternalStylesheet` option again due to a route resolution bug.

Sadly, this bug didn't occur before actually publishing the package - it worked fine when linking the package locally. Insert sad trombone sound here.
