### PR TITLE
Fix unexpected file name comment detections

### DIFF
--- a/.changeset/few-donuts-wait.md
+++ b/.changeset/few-donuts-wait.md
@@ -1,5 +1,8 @@
 ---
 '@expressive-code/plugin-frames': patch
+'astro-expressive-code': patch
+'expressive-code': patch
+'remark-expressive-code': patch
 ---
 
 Comments like `// ...` are now no longer incorrectly detected as file names. Thanks @kdheepak!

--- a/.changeset/few-donuts-wait.md
+++ b/.changeset/few-donuts-wait.md
@@ -1,0 +1,5 @@
+---
+'@expressive-code/plugin-frames': patch
+---
+
+Comments like `// ...` are now no longer incorrectly detected as file names. Thanks @kdheepak!

--- a/packages/@expressive-code/plugin-frames/src/utils.ts
+++ b/packages/@expressive-code/plugin-frames/src/utils.ts
@@ -97,6 +97,12 @@ export function getFileNameFromComment(line: string, lang: string): string | und
 	const possibleFileName = matches?.[2]
 	if (!possibleFileName) return
 
+	// Ignore strings that only consist of special characters (dots, path separators, etc.)
+	if (!possibleFileName.match(/[^.:/\\~]/)) return
+
+	// Ignore strings starting with two or more dots not followed by a path separator
+	if (possibleFileName.match(/^\.{2,}(?!\/|\\)/)) return
+
 	// Check if the syntax highlighting language is contained in our known language groups,
 	// and determine the extension of the extracted file name (if any)
 	const languageGroup = Object.values(LanguageGroups).find((group) => group.includes(lang))

--- a/packages/@expressive-code/plugin-frames/test/preprocess-code.test.ts
+++ b/packages/@expressive-code/plugin-frames/test/preprocess-code.test.ts
@@ -129,7 +129,10 @@ No page will be built for this post.
 		'path\\to\\file',
 		// Relative file paths
 		'./test',
+		'../src',
+		'../../images',
 		'.\\Temp',
+		'..\\src',
 		// Absolute unix file paths
 		'/etc/hosts',
 		'~/some_file',
@@ -354,6 +357,10 @@ import { defineConfig } from 'example/config'
 			'# Allow: /',
 			'# cat /etc/profile',
 			'/// <reference types="astro/client" />',
+			'// Testing...',
+			'// ...loading',
+			'// ...',
+			'// ..',
 		]
 		const languages = ['js', 'sh']
 		await runPreprocessingTests(


### PR DESCRIPTION
Addresses https://github.com/withastro/starlight/issues/1158 by adding rules that prevent comments like `// ...` from being incorrectly detected as file names. Thanks @kdheepak!