### PR TITLE
Docs: Add documentation on how to add the collapsible sections plugin to a Starlight project

### DIFF
--- a/docs/src/content/docs/plugins/collapsible-sections.mdx
+++ b/docs/src/content/docs/plugins/collapsible-sections.mdx
@@ -11,6 +11,8 @@ The lines of collapsed sections will be replaced by a clickable `X collapsed l
 
 ## Installation
 
+### Astro
+
 Before being able to use collapsible sections in your code blocks, you need to install the plugin as a dependency and add it to your configuration:
 
 1. Add the package to your site's dependencies:
@@ -48,6 +50,50 @@ Before being able to use collapsible sections in your code blocks, you need to i
             pluginCollapsibleSections(),
           ],
         }),
+      ],
+    })
+    ```
+
+### Starlight
+
+Before being able to use collapsible sections in your code blocks, you need to install the plugin as a dependency and add it to your configuration:
+
+1. Add the package to your site's dependencies:
+
+    <Tabs>
+      <TabItem label="npm">
+      ```sh
+      npm i @expressive-code/plugin-collapsible-sections
+      ```
+      </TabItem>
+      <TabItem label="pnpm">
+      ```sh
+      pnpm i @expressive-code/plugin-collapsible-sections
+      ```
+      </TabItem>
+      <TabItem label="yarn">
+      ```sh
+      yarn add @expressive-code/plugin-collapsible-sections
+      ```
+      </TabItem>
+    </Tabs>
+
+2. Add the integration to starlights configuration by adding it to the `plugins` list of the `expressiveCode` configuration object in your starlight configuration.
+
+    ```js ins={4,10-12}
+    // astro.config.mjs
+    import { defineConfig } from 'astro/config'
+    import starlight from '@astrojs/starlight'
+    import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-sections'
+
+    export default defineConfig({
+      integrations: [
+        starlight({
+          title: 'example.com',
+          expressiveCode: {
+            plugins: [ pluginCollapsibleSections() ],
+          },
+        ]),
       ],
     })
     ```

--- a/docs/src/content/docs/plugins/collapsible-sections.mdx
+++ b/docs/src/content/docs/plugins/collapsible-sections.mdx
@@ -78,7 +78,7 @@ Before being able to use collapsible sections in your code blocks, you need to i
       </TabItem>
     </Tabs>
 
-2. Add the integration to starlights configuration by adding it to the `plugins` list of the `expressiveCode` configuration object in your starlight configuration.
+2. Add the integration to Starlight's configuration by adding it to the `plugins` list of the `expressiveCode` configuration object in your Starlight configuration.
 
     ```js ins={4,10-12}
     // astro.config.mjs


### PR DESCRIPTION
Adding the collapsible sections plugin to a Starlight project works a bit differently from adding the plugin to a vanilla Astro project. Similar to the `Installation` page this PR adds additional documentation on how to add the plugin to a Starlight project.