### PR TITLE
Fix color contrast correction when using CSS variables

### DIFF
--- a/.changeset/chilled-lizards-tap.md
+++ b/.changeset/chilled-lizards-tap.md
@@ -1,0 +1,11 @@
+---
+'@expressive-code/plugin-text-markers': patch
+'@expressive-code/core': patch
+'astro-expressive-code': patch
+'expressive-code': patch
+'remark-expressive-code': patch
+---
+
+Improves automatic color contrast correction when using CSS variables in styleOverrides. Thanks @heycassidy!
+
+It is now possible to use CSS variables in the `styleOverrides` setting `codeBackground` without negatively affecting the automatic color contrast correction controlled by the `minSyntaxHighlightingColorContrast` setting. If a CSS variable is encountered that cannot be resolved to a color value on the server, Expressive Code now automatically uses the theme's background color as a fallback for color contrast calculations. You can also provide your own fallback color using the CSS variable fallback syntax, e.g. `var(--gray-50, #f9fafb)`.

--- a/docs/src/content/docs/reference/core-api.mdx
+++ b/docs/src/content/docs/reference/core-api.mdx
@@ -526,11 +526,13 @@ Returns the same `ExpressiveCodeTheme` instance to allow chaining.
 
 ##### ensureMinSyntaxHighlightingColorContrast()
 
-- <code class="function-signature">**ensureMinSyntaxHighlightingColorContrast**(minContrast): [ExpressiveCodeTheme](/reference/core-api/#expressivecodetheme)</code>
+- <code class="function-signature">**ensureMinSyntaxHighlightingColorContrast**(minContrast, backgroundColor?): [ExpressiveCodeTheme](/reference/core-api/#expressivecodetheme)</code>
 
 Processes the theme's syntax highlighting colors to ensure a minimum contrast ratio between foreground and background colors.
 
 The default value of 5.5 ensures optimal accessibility with a contrast ratio of 5.5:1.
+
+You can optionally pass a custom background color to use for the contrast checks. By default, the theme's background color will be used.
 
 Returns the same `ExpressiveCodeTheme` instance to allow chaining.
 
@@ -539,6 +541,7 @@ Returns the same `ExpressiveCodeTheme` instance to allow chaining.
 | Parameter | Type | Default value |
 | :------ | :------ | :------ |
 | `minContrast` | `number` | `5.5` |
+| `backgroundColor`? | `string` | `undefined` |
 
 ##### fromJSONString()
 

--- a/internal/test-utils/package.json
+++ b/internal/test-utils/package.json
@@ -16,8 +16,11 @@
     "@types/node": "^18.15.11",
     "hast-util-select": "^5.0.5",
     "hast-util-to-html": "^8.0.4",
+    "hast-util-to-text": "^3.1.2",
     "postcss": "^8.4.29",
     "shikiji": "^0.8.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "unist-util-visit": "^4.1.2",
+    "unist-util-visit-parents": "^5.1.3"
   }
 }

--- a/internal/test-utils/src/color-contrast.ts
+++ b/internal/test-utils/src/color-contrast.ts
@@ -1,0 +1,137 @@
+import { visit } from 'unist-util-visit'
+import { visitParents } from 'unist-util-visit-parents'
+import { toText } from 'hast-util-to-text'
+import { Element } from 'hast-util-to-text/lib'
+import { Parent, StyleSettingPath, StyleVariant, getClassNames, getColorContrast, getStaticBackgroundColor, onBackground } from '@expressive-code/core'
+
+export function validateColorContrast({ renderedGroupAst, styleVariants }: { renderedGroupAst: Parent; styleVariants: StyleVariant[] }) {
+	const themesWithInsufficientContrast: string[] = []
+	const expectedMinContrast = 4.5
+	const linesInGroupAst = getLineNodes(renderedGroupAst)
+	styleVariants.forEach((styleVariant, styleVariantIndex) => {
+		// Calculate the contrast of all syntax tokens against their combined background colors
+		const tokenColors: { text: string; bg: string; fg: string; contrast: number | undefined; lineIndex: number }[] = []
+		visitParents(renderedGroupAst, 'element', (token, ancestors) => {
+			// Only process spans with a style attribute
+			if (token.tagName !== 'span') return
+			const style = token.properties?.style?.toString()
+			if (!style) return
+			// Determine the current foreground color by walking the ancestor chain
+			// from the current token to the root and extracting the first foreground color
+			// for the current style variant index
+			const fg = getForegroundColor({ token, ancestors, styleVariant, styleVariantIndex })
+			if (!fg) throw new Error(`Could not determine foreground color of token: ${style}`)
+			// Determine the combined background color by walking the ancestor chain
+			// from the root to the current token
+			const bg = getBackgroundColor({ token, ancestors, styleVariant })
+			const text = toText(token)
+			const contrast = fg && bg ? getColorContrast(fg, bg) : undefined
+			tokenColors.push({
+				text,
+				bg,
+				fg,
+				contrast,
+				lineIndex: getLineIdx({ token, ancestors, linesInGroupAst }),
+			})
+		})
+
+		const insufficientContrastTokens = tokenColors
+			.filter((token) => token.text.trim() !== '' && (token.contrast === undefined || token.contrast < expectedMinContrast))
+			.map(
+				(token) =>
+					`Line ${token.lineIndex + 1}, token: "${token.text}" (${[
+						`fg: ${token.fg ?? 'undefined'}`,
+						`bg: ${token.bg ?? 'undefined'}`,
+						`contrast: ${token.contrast !== undefined ? Math.round(token.contrast * 10) / 10 : 'undefined'}`,
+					].join(', ')})`
+			)
+			.join('\n')
+		if (insufficientContrastTokens !== '') {
+			themesWithInsufficientContrast.push(`*** Theme "${styleVariant.theme.name}" has insufficient contrast (expected ${expectedMinContrast}):\n${insufficientContrastTokens}`)
+		}
+	})
+	if (themesWithInsufficientContrast.length > 0) {
+		throw new Error(`Expected no themes with insufficient contrast, but found:\n\n${themesWithInsufficientContrast.join('\n\n')}\n\n`)
+	}
+}
+
+function getResolvedColors(styleVariant: StyleVariant) {
+	const getSetting = (setting: string) => {
+		const value = styleVariant.resolvedStyleSettings.get(setting as StyleSettingPath)
+		if (!value) throw new Error(`Could not extract ${setting} from style settings`)
+		return value
+	}
+	return {
+		codeFg: getSetting('codeForeground'),
+		codeBg: getStaticBackgroundColor(styleVariant),
+		markBg: getSetting('textMarkers.markBackground'),
+		delBg: getSetting('textMarkers.delBackground'),
+		insBg: getSetting('textMarkers.insBackground'),
+	}
+}
+
+function getForegroundColor({ token, ancestors, styleVariant, styleVariantIndex }: { token: Parent; ancestors: Parent[]; styleVariant: StyleVariant; styleVariantIndex: number }) {
+	const nodes = [...ancestors, token]
+	for (let i = nodes.length - 1; i >= 0; i--) {
+		const node = nodes[i]
+		if (node.type !== 'element') continue
+		if (node.tagName === 'span') {
+			const style = node.properties?.style?.toString()
+			if (style) {
+				// Try to extract the foreground color of the current style variant index
+				const fg = style.match(new RegExp(`(?:^|;)--${styleVariantIndex}:(#.*?)(?:;|$)`))?.[1]
+				if (fg) return fg
+			}
+		}
+	}
+	// If no foreground color was found, return the default foreground color
+	const colors = getResolvedColors(styleVariant)
+	return colors.codeFg
+}
+
+function getBackgroundColor({ token, ancestors, styleVariant }: { token: Parent; ancestors: Parent[]; styleVariant: StyleVariant }) {
+	const colors = getResolvedColors(styleVariant)
+	let combinedBg = colors.codeBg
+	const nodes = [...ancestors, token]
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i]
+		if (node.type !== 'element') continue
+		const classes = getClassNames(node)
+		let nodeBg: string | undefined = undefined
+		if (node.tagName === 'div' && classes.includes('ec-line')) {
+			if (classes.includes('mark')) nodeBg = colors.markBg
+			if (classes.includes('del')) nodeBg = colors.delBg
+			if (classes.includes('ins')) nodeBg = colors.insBg
+		}
+		if (node.tagName === 'mark') nodeBg = colors.markBg
+		if (node.tagName === 'del') nodeBg = colors.delBg
+		if (node.tagName === 'ins') nodeBg = colors.insBg
+
+		if (nodeBg) {
+			combinedBg = onBackground(nodeBg, combinedBg)
+		}
+	}
+	return combinedBg
+}
+
+function getLineNodes(renderedGroupAst: Parent) {
+	const linesInGroupAst: Element[] = []
+	visit(renderedGroupAst, 'element', (node) => {
+		if (node.tagName === 'div' && getClassNames(node).includes('ec-line')) {
+			linesInGroupAst.push(node)
+		}
+	})
+	return linesInGroupAst
+}
+
+function getLineIdx({ token, ancestors, linesInGroupAst }: { token: Parent; ancestors: Parent[]; linesInGroupAst: Element[] }) {
+	const nodes = [...ancestors, token]
+	for (let i = 0; i < nodes.length; i++) {
+		const node = nodes[i]
+		if (node.type !== 'element') continue
+		const lineIdx = linesInGroupAst.indexOf(node)
+		if (lineIdx > -1) return lineIdx
+	}
+
+	return -1
+}

--- a/internal/test-utils/src/index.ts
+++ b/internal/test-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './color-contrast'
 export * from './css'
 export * from './html-snapshots'
 export * from './themes'

--- a/packages/@expressive-code/plugin-text-markers/test/data/marker-examples.ts
+++ b/packages/@expressive-code/plugin-text-markers/test/data/marker-examples.ts
@@ -1,0 +1,37 @@
+export const lineMarkerTestText = `
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  markdown: {
+    extendDefaultPlugins: false,
+    smartypants: false,
+    gfm: false,
+  }
+});
+`.trim()
+
+export const inlineMarkerTestText = `
+---
+const { greeting = "Hello", name = "Astronaut" } = Astro.props;
+---
+<h2>{greeting}, punymighty {name}!</h2>
+`.trim()
+
+export const colorContrastTestText = `
+---
+layout: ../../layouts/BaseLayout.astro
+title: 'My first MDX post'
+publishDate: '21 September 2022'
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export function fancyJsHelper() {
+  return "Try doing that with YAML!";
+}
+
+<BaseLayout title={frontmatter.title} fancyJsHelper={fancyJsHelper}>
+  Welcome to my new Astro blog, using MDX!
+</BaseLayout>
+`.trim()
+
+export const colorContrastTestMeta = `title="src/pages/posts/first-post.mdx" ins={6} mark={9} del={2} /</?BaseLayout>/ /</?BaseLayout title={frontmatter.title} fancyJsHelper={fancyJsHelper}>/`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       hast-util-to-html:
         specifier: ^8.0.4
         version: 8.0.4
+      hast-util-to-text:
+        specifier: ^3.1.2
+        version: 3.1.2
       postcss:
         specifier: ^8.4.29
         version: 8.4.29
@@ -157,6 +160,12 @@ importers:
       typescript:
         specifier: ^5.0.4
         version: 5.0.4
+      unist-util-visit:
+        specifier: ^4.1.2
+        version: 4.1.2
+      unist-util-visit-parents:
+        specifier: ^5.1.3
+        version: 5.1.3
 
   packages/@expressive-code/core:
     dependencies:


### PR DESCRIPTION
Improves automatic color contrast correction when using CSS variables in styleOverrides. Fixes #144. Thanks @heycassidy!

This PR makes it possible to use CSS variables in the `styleOverrides` setting `codeBackground` without negatively affecting the automatic color contrast correction controlled by the `minSyntaxHighlightingColorContrast` setting.

If a CSS variable is encountered that cannot be resolved to a color value on the server, Expressive Code now automatically uses the theme's background color as a fallback for color contrast calculations. You can also provide your own fallback color using the CSS variable fallback syntax, e.g. `var(--gray-50, #f9fafb)`.
