### PR TITLE
Fix indent wrapping causing empty lines

### DIFF
--- a/.changeset/plenty-doors-guess.md
+++ b/.changeset/plenty-doors-guess.md
@@ -1,0 +1,8 @@
+---
+'@expressive-code/core': patch
+'expressive-code': patch
+'astro-expressive-code': patch
+'remark-expressive-code': patch
+---
+
+Fixes an issue where lines containing a very long word after the initial indentation would wrap incorrectly.

--- a/packages/@expressive-code/core/src/common/engine.ts
+++ b/packages/@expressive-code/core/src/common/engine.ts
@@ -11,6 +11,7 @@ import { ExpressiveCodeLogger, ExpressiveCodeLoggerOptions } from './logger'
 import { resolveStyleSettings } from '../internal/style-resolving'
 import { getFirstStaticColor } from '../helpers/color-transforms'
 import { ExpressiveCodeBlock } from './block'
+import { corePlugins } from '../internal/core-plugins'
 
 export interface ExpressiveCodeEngineConfig {
 	/**
@@ -246,7 +247,7 @@ export class ExpressiveCodeEngine implements ResolvedExpressiveCodeEngineConfig 
 		this.styleOverrides = { ...config.styleOverrides }
 		this.defaultLocale = config.defaultLocale || 'en-US'
 		this.defaultProps = config.defaultProps || {}
-		this.plugins = config.plugins?.flat() || []
+		this.plugins = [...corePlugins, ...(config.plugins?.flat() || [])]
 		this.logger = new ExpressiveCodeLogger(config.logger)
 
 		// Allow customizing the loaded themes

--- a/packages/@expressive-code/core/src/internal/core-plugins.ts
+++ b/packages/@expressive-code/core/src/internal/core-plugins.ts
@@ -1,0 +1,39 @@
+import { AnnotationRenderOptions, ExpressiveCodeAnnotation, InlineStyleAnnotation } from '../common/annotation'
+import { ExpressiveCodePlugin } from '../common/plugin'
+import { h } from 'hastscript'
+
+export const corePlugins: ExpressiveCodePlugin[] = [
+	{
+		name: 'Indent Wrapper',
+		hooks: {
+			postprocessAnnotations: ({ codeBlock }) => {
+				codeBlock.getLines().forEach((line) => {
+					const indent = line.text.match(/^\s+/)?.[0].length ?? 0
+					if (indent > 0) {
+						// Remove any unnecessary inline styles inside the indent
+						line.getAnnotations().forEach((annotation) => {
+							const { inlineRange } = annotation
+							if (!inlineRange || !(annotation instanceof InlineStyleAnnotation)) return
+							if (inlineRange.columnStart >= 0 && inlineRange?.columnEnd <= indent) {
+								line.deleteAnnotation(annotation)
+							}
+						})
+						// Add an annotation to the indent to prevent wrapping
+						line.addAnnotation(
+							new IndentAnnotation({
+								inlineRange: { columnStart: 0, columnEnd: indent },
+								renderPhase: 'earlier',
+							})
+						)
+					}
+				})
+			},
+		},
+	},
+]
+
+class IndentAnnotation extends ExpressiveCodeAnnotation {
+	render({ nodesToTransform }: AnnotationRenderOptions) {
+		return nodesToTransform.map((node) => h('span.indent', node))
+	}
+}

--- a/packages/@expressive-code/core/src/internal/core-styles.ts
+++ b/packages/@expressive-code/core/src/internal/core-styles.ts
@@ -288,6 +288,9 @@ export function getCoreBaseStyles({
 				white-space: pre-wrap;
 				overflow-wrap: break-word;
 				min-width: min(30ch, var(--ecMaxLine, 30ch));
+				& span.indent {
+					white-space: pre;
+				}
 			}
 
 			${ifThemedScrollbars(`

--- a/packages/@expressive-code/core/test/objects.test.ts
+++ b/packages/@expressive-code/core/test/objects.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { getStableObjectHash, stableStringify } from '../src/helpers/objects'
 import { ExpressiveCodeEngine } from '../src/common/engine'
+import { ExpressiveCodePlugin } from '../src/common/plugin'
 
 describe('stableStringify()', () => {
 	test('Returns a stable sort order', () => {
@@ -113,27 +114,25 @@ describe('stableStringify()', () => {
 		expect(stableStringify(obj, { includeFunctionContents: true })).toBe('{"a":1,"b":2,"c":"(input) => input.length"}')
 	})
 	test('Serializes an Expressive Code plugins array', () => {
-		const engine = new ExpressiveCodeEngine({
-			plugins: [
-				{
-					name: 'test',
-					hooks: {
-						preprocessMetadata: ({ codeBlock }) => {
-							codeBlock.meta = ''
-						},
+		const plugins: ExpressiveCodePlugin[] = [
+			{
+				name: 'test',
+				hooks: {
+					preprocessMetadata: ({ codeBlock }) => {
+						codeBlock.meta = ''
 					},
 				},
-				{
-					name: 'another-test',
-					hooks: {
-						annotateCode: ({ addStyles }) => {
-							addStyles('body { background: red; }')
-						},
+			},
+			{
+				name: 'another-test',
+				hooks: {
+					annotateCode: ({ addStyles }) => {
+						addStyles('body { background: red; }')
 					},
 				},
-			],
-		})
-		expect(stableStringify(engine.plugins)).toBe(
+			},
+		]
+		expect(stableStringify(plugins)).toBe(
 			`[${[
 				'{"hooks":{"preprocessMetadata":"[Function]"},"name":"test"}',
 				// Validate that hooks are not sorted alphabetically,

--- a/packages/@expressive-code/plugin-shiki/test/rendering.test.ts
+++ b/packages/@expressive-code/plugin-shiki/test/rendering.test.ts
@@ -227,11 +227,11 @@ describe('Renders syntax highlighting', async () => {
 						expect(html).not.toMatch(ansiEscapeCode)
 
 						// Expect the ANSI colors of the "github-dark" theme to be present
-						expect(html).toMatch(/<span [^>]*?style="[^"]*?:#56d4dd[^"]*?"> Context Testing ANSI<\/span>/)
+						expect(html).toMatch(/<span [^>]*?style="[^"]*?:#56d4dd[^"]*?">Context Testing ANSI<\/span>/)
 						expect(html).toMatch(/<span [^>]*?style="[^"]*?:#fafbfc[^"]*?">Tests Passed: 1 <\/span>/)
 
 						// Also expect the ANSI colors of the "dracula" theme to be present
-						expect(html).toMatch(/<span [^>]*?style="[^"]*?:#a4ffff[^"]*?"> Context Testing ANSI<\/span>/)
+						expect(html).toMatch(/<span [^>]*?style="[^"]*?:#a4ffff[^"]*?">Context Testing ANSI<\/span>/)
 						expect(html).toMatch(/<span [^>]*?style="[^"]*?:#ffffff[^"]*?">Tests Passed: 1 <\/span>/)
 
 						colorAssertionExecuted = true

--- a/packages/expressive-code/test/constructor.test.ts
+++ b/packages/expressive-code/test/constructor.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from 'vitest'
-import { ExpressiveCode } from '../src'
+import { ExpressiveCode, ExpressiveCodePlugin } from '../src'
 
 describe('ExpressiveCode constructor', () => {
+	const onlyDefault = (plugins: readonly ExpressiveCodePlugin[]) =>
+		plugins.filter((plugin) => {
+			return ['Shiki', 'TextMarkers', 'Frames'].includes(plugin.name)
+		})
 	test('Adds all bundled plugins by default', () => {
 		const ec = new ExpressiveCode()
-		expect(ec.plugins).toMatchObject([
+		expect(onlyDefault(ec.plugins)).toMatchObject([
 			// Validate plugin names and order
 			{ name: 'Shiki' },
 			{ name: 'TextMarkers' },
@@ -15,7 +19,7 @@ describe('ExpressiveCode constructor', () => {
 		const ec = new ExpressiveCode({
 			shiki: false,
 		})
-		expect(ec.plugins).toMatchObject([
+		expect(onlyDefault(ec.plugins)).toMatchObject([
 			// Validate plugin names and order
 			{ name: 'TextMarkers' },
 			{ name: 'Frames' },


### PR DESCRIPTION
Fixes an issue where lines containing a very long word after the initial indentation would wrap incorrectly.

Internally, this is done by an auto-added core plugin that wraps the initial indentation of each line inside a special `<span class="indent">...</span>` annotation that prevents it from wrapping.