### PR TITLE
Add `prerender: true` to injected routes

### DIFF
--- a/.changeset/tough-pandas-prove.md
+++ b/.changeset/tough-pandas-prove.md
@@ -1,0 +1,5 @@
+---
+'astro-expressive-code': patch
+---
+
+Adds `prerender: true` flag to injected asset routes to enable hybrid rendering once it's also supported for `.ts` entrypoints by Astro.

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -68,6 +68,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 					injectRoute({
 						pattern: hashedRoute,
 						entrypoint,
+						prerender: true,
 						// @ts-expect-error: Also provide the old property name used in Astro 3
 						entryPoint: entrypoint,
 					})
@@ -77,6 +78,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 					injectRoute({
 						pattern: hashedRoute,
 						entrypoint,
+						prerender: true,
 						// @ts-expect-error: Also provide the old property name used in Astro 3
 						entryPoint: entrypoint,
 					})


### PR DESCRIPTION
This brings us another step closer to fixing #108, but we're still waiting for a full fix within Astro core that actually adds support for prerendering injected `.ts` routes.