### PR TITLE
Clone TinyColor with toRgb

### DIFF
--- a/.changeset/stupid-keys-reflect.md
+++ b/.changeset/stupid-keys-reflect.md
@@ -1,0 +1,5 @@
+---
+'@expressive-code/core': patch
+---
+
+Clones internal TinyColor instance with an object input instead of string input for faster parsing performance

--- a/packages/@expressive-code/core/src/helpers/color-transforms.ts
+++ b/packages/@expressive-code/core/src/helpers/color-transforms.ts
@@ -352,7 +352,7 @@ function withParsedColor(input: string, transform: (color: TinyColor) => string,
 function toTinyColor(input: string | TinyColor | RgbaColor | Hsl | Oklch) {
 	if (input instanceof TinyColor) {
 		// We use this instead of clone() because clone performs unwanted rounding
-		return new TinyColor(input.toHexShortString())
+		return new TinyColor(input.toRgb())
 	}
 	if (typeof input === 'string') {
 		// Detect CSS lab() color notation as input and convert it to RGBA


### PR DESCRIPTION
Cloning `TinyColor` using an object instead of a string is faster as `TinyColor` doesn't have to guess the format of the string on init.

- https://github.com/scttcper/tinycolor/blob/64270d80c1287355c6c9f719baa6777d5eac3ee5/src/format-input.ts#L122
- https://github.com/scttcper/tinycolor/blob/64270d80c1287355c6c9f719baa6777d5eac3ee5/src/format-input.ts#L46-L48

Locally, this drops the execution time of `toTinyColor` from 2.55s to 2.06s:

<img width="629" alt="image" src="https://github.com/expressive-code/expressive-code/assets/34116392/5b21d012-e67b-402f-acb2-3a05a79c3eb0">

<img width="628" alt="image" src="https://github.com/expressive-code/expressive-code/assets/34116392/19b92f8f-3035-4392-aa41-c76d1d9519b9">

