### PR TITLE
Fix `plugin-frames` not processing commented file names containing `+` as titles

### DIFF
--- a/.changeset/quick-dragons-cover.md
+++ b/.changeset/quick-dragons-cover.md
@@ -1,0 +1,5 @@
+---
+'@expressive-code/plugin-frames': patch
+---
+
+- Fixes file names prefixed with `+` not processing as a file name comment

--- a/packages/@expressive-code/plugin-frames/src/utils.ts
+++ b/packages/@expressive-code/plugin-frames/src/utils.ts
@@ -64,7 +64,7 @@ const getFileNameCommentRegExpString = () =>
 		// Optional Windows drive letter
 		`(?:[a-z]:)?`,
 		// Optional sequence of characters allowed in file paths
-		`[\\w./~%[\\]\\\\-]*`,
+		`[\\w./~%[\\]+\\\\-]*`,
 		// Optional dot and supported file extension
 		`(?:\\.(?:${Object.values(LanguageGroups).flat().sort().join('|')}))?`,
 		// End of file name capture

--- a/packages/@expressive-code/plugin-frames/test/preprocess-code.test.ts
+++ b/packages/@expressive-code/plugin-frames/test/preprocess-code.test.ts
@@ -9,6 +9,10 @@ describe('Extracts file name comments from the first code lines', () => {
 			{
 				fileName: 'test.config.mjs',
 			},
+			// Should match + in file name
+			{
+				fileName: '+layout.svelte',
+			},
 		])
 	})
 
@@ -23,6 +27,12 @@ describe('Extracts file name comments from the first code lines', () => {
 				fileName: 'test.config.ts',
 				commentSyntax: `// Fichier d'exemple : {fileName}`,
 				language: 'ts',
+			},
+			// Should match + in file name
+			{
+				fileName: '+layout.svelte',
+				commentSyntax: `// Example file: {fileName}`,
+				language: 'svelte',
 			},
 		])
 	})


### PR DESCRIPTION
### plugin-frames

**Changes**
* Modifies file name regex string to include + in file names
* Added tests to cover +layout.svelte use case

Resolves #204 

**Context**
File name comments were not processing as titles for SvelteKit file names like `+layout.svelte` and `+page.server.ts`.