### PR TITLE
Add transformers option to shiki plugin

### DIFF
--- a/.changeset/friendly-pans-lay.md
+++ b/.changeset/friendly-pans-lay.md
@@ -5,7 +5,7 @@
 'rehype-expressive-code': minor
 ---
 
-Adds the experimental `transformers` option to the Shiki plugin.
+Adds the experimental `transformers` option to the Shiki plugin. Thank you @MichaelMakesGames!
 
 This option allows you to specify a list of Shiki transformers to be called during syntax highlighting.
 

--- a/.changeset/friendly-pans-lay.md
+++ b/.changeset/friendly-pans-lay.md
@@ -1,0 +1,16 @@
+---
+'@expressive-code/plugin-shiki': minor
+'astro-expressive-code': minor
+'expressive-code': minor
+'rehype-expressive-code': minor
+---
+
+Adds the experimental `transformers` option to the Shiki plugin.
+
+This option allows you to specify a list of Shiki transformers to be called during syntax highlighting.
+
+**Important:** This option is marked as experimental because it only supports a **very limited subset** of Shiki transformer features right now. Most importantly, transformers cannot modify a code block's text contents in any way, so most popular transformers will not work.
+
+In its current state, this option allows you to use transformers that solely modify the tokens produced by Shiki to improve syntax highlighting, e.g. applying bracket matching or changing the color of certain tokens.
+
+Attempting to pass incompatible transformers to this option will throw an error. This is not a bug, neither in Expressive Code, nor in Shiki or the transformers. Please do not report incompatibilities to other authors, as they are unable to fix them. The current limitations exist because the Shiki transformer API is incompatible with Expressive Code's architecture, and we will continue to work on closing the gap and improving this feature.

--- a/packages/@expressive-code/plugin-shiki/src/index.ts
+++ b/packages/@expressive-code/plugin-shiki/src/index.ts
@@ -16,14 +16,6 @@ export interface PluginShikiOptions {
 	 */
 	langs?: LanguageInput[] | undefined
 	/**
-	 * Whether to include explanation information on Shiki tokens.
-	 *
-	 * Enabling this option will increase the time required to highlight code blocks,
-	 * but might be required by certain transformers or plugins. Do not enable this
-	 * unless you're specifically asked to do so by a transformer or plugin.
-	 */
-	includeExplanation?: boolean | undefined
-	/**
 	 * An optional list of Shiki transformers.
 	 *
 	 * **Warning:** This option is experimental and only supports a very limited subset of
@@ -116,7 +108,7 @@ export function pluginShiki(options: PluginShikiOptions = {}): ExpressiveCodePlu
 						const codeToTokensOptions = {
 							lang: loadedLanguageName,
 							theme: loadedThemeName,
-							includeExplanation: options.includeExplanation ?? false,
+							includeExplanation: false,
 						}
 
 						// Run preprocess hook of all configured transformers

--- a/packages/@expressive-code/plugin-shiki/src/transformers.ts
+++ b/packages/@expressive-code/plugin-shiki/src/transformers.ts
@@ -1,0 +1,113 @@
+import { ExpressiveCodeBlock } from '@expressive-code/core'
+import type { PluginShikiOptions } from '.'
+import type { CodeToHastOptions, ShikiTransformer, ShikiTransformerContextSource, ThemedToken } from 'shiki'
+
+export type BaseHookArgs = {
+	options: PluginShikiOptions
+	code: string
+	codeBlock: ExpressiveCodeBlock
+	codeToTokensOptions: CodeToHastOptions
+}
+
+/**
+ * Throws an error if any of the configured transformers use unsupported hooks.
+ */
+export function validateTransformers(options: PluginShikiOptions) {
+	if (!options.transformers) return
+	const unsupportedTransformerHooks: (keyof ShikiTransformer)[] = ['code', 'line', 'postprocess', 'pre', 'root', 'span']
+	for (const transformer of options.transformers) {
+		const unsupportedHook = unsupportedTransformerHooks.find((hook) => transformer[hook] != null)
+		if (unsupportedHook) {
+			throw new ExpressiveCodeShikiTransformerError(transformer, `The transformer hook "${unsupportedHook}" is not supported by Expressive Code yet.`)
+		}
+	}
+}
+
+export function runPreprocessHook(args: BaseHookArgs) {
+	const { options, code, codeBlock, codeToTokensOptions } = args
+	options.transformers?.forEach((transformer) => {
+		if (!transformer.preprocess) return
+		const transformerContext = getTransformerContext({ transformer, code, codeBlock, codeToTokensOptions })
+		const transformedCode = transformer.preprocess.call(transformerContext, code, codeToTokensOptions)
+		if (typeof transformedCode === 'string' && transformedCode !== code) {
+			throw new ExpressiveCodeShikiTransformerError(transformer, `Transformers that modify code in the "preprocess" hook are not supported yet.`)
+		}
+	})
+}
+
+export function runTokensHook(args: BaseHookArgs & { tokenLines: ThemedToken[][] }) {
+	const { options, code, codeBlock, codeToTokensOptions } = args
+	const originalTokenLinesLength = args.tokenLines.length
+	options.transformers?.forEach((transformer) => {
+		if (!transformer.tokens) return
+		const transformerContext = getTransformerContext({ transformer, code, codeBlock, codeToTokensOptions })
+		const transformedTokenLines = transformer.tokens.call(transformerContext, args.tokenLines)
+		// Transformers can either mutate the tokens in place,
+		// or return a new array of tokens
+		if (transformedTokenLines) {
+			args.tokenLines = transformedTokenLines
+		}
+		// Ensure that the number of token lines has not changed
+		if (originalTokenLinesLength !== args.tokenLines.length) {
+			throw new ExpressiveCodeShikiTransformerError(
+				transformer,
+				`Transformers that modify code in the "tokens" hook are not supported yet. The number of lines changed from ${originalTokenLinesLength} to ${args.tokenLines.length}.`
+			)
+		}
+		// Ensure that the text contents of each line have not changed
+		for (let i = 0; i < args.tokenLines.length; i++) {
+			const originalText = codeBlock.getLine(i)?.text
+			const newText = args.tokenLines[i].map((token) => token.content).join('')
+			if (originalText !== newText) {
+				throw new ExpressiveCodeShikiTransformerError(
+					transformer,
+					`Transformers that modify code in the "tokens" hook are not supported yet. Line ${i + 1} changed from "${originalText}" to "${newText}".`
+				)
+			}
+		}
+	})
+	return args.tokenLines
+}
+
+export function getTransformerContext(contextBase: {
+	transformer: ShikiTransformer
+	code: string
+	codeBlock: ExpressiveCodeBlock
+	codeToTokensOptions: CodeToHastOptions
+}): ShikiTransformerContextSource {
+	const { transformer, code, codeBlock, codeToTokensOptions } = contextBase
+	const getUnsupportedFnHandler = (name: string) => {
+		return () => {
+			throw new ExpressiveCodeShikiTransformerError(transformer, `The context function "${name}" is not available in Expressive Code transformers yet.`)
+		}
+	}
+	return {
+		source: code,
+		options: codeToTokensOptions,
+		meta: {
+			...(Object.fromEntries(codeBlock.metaOptions.list().map((option) => [option.key, option.value])) as Record<string, string | boolean | RegExp>),
+			__raw: codeBlock.meta,
+		},
+		codeToHast: getUnsupportedFnHandler('codeToHast'),
+		codeToTokens: getUnsupportedFnHandler('codeToTokens'),
+	}
+}
+
+export class ExpressiveCodeShikiTransformerError extends Error {
+	constructor(transformer: ShikiTransformer, message: string) {
+		super(
+			`Failed to run Shiki transformer${transformer.name ? ` "${transformer.name}"` : ''}: ${message}
+			
+			IMPORTANT: This is not a bug - neither in Shiki, nor in the transformer or Expressive Code.
+			Transformer support in Expressive Code is still experimental and limited to a few cases
+			(e.g. transformers that modify syntax highlighting tokens).
+
+			To continue, remove this transformer from the Expressive Code configuration,
+			or visit the following link for more information and other options:
+			https://expressive-code.com/key-features/syntax-highlighting/#transformers`
+				.replace(/^\t+/gm, '')
+				.replace(/(?<!\n)\n(?!\n)/g, ' ')
+		)
+		this.name = 'ExpressiveCodeShikiTransformerError'
+	}
+}

--- a/packages/@expressive-code/plugin-shiki/test/rendering.test.ts
+++ b/packages/@expressive-code/plugin-shiki/test/rendering.test.ts
@@ -520,35 +520,6 @@ describe('Supports a limited subset of Shiki transformers', async () => {
 		)
 
 		test(
-			'Provides token explanations if "includeExplanation" is true',
-			async ({ task: { name: testName } }) => {
-				const scopesTransformer: ShikiTransformer = {
-					tokens(tokens: ThemedToken[][]) {
-						for (const line of tokens) {
-							for (const token of line) {
-								if (token.explanation == null) {
-									throw Error('Expected explanation')
-								}
-							}
-						}
-					},
-				}
-				// Just test that this doesn't throw
-				await renderAndOutputHtmlSnapshot({
-					testName,
-					testBaseDir: __dirname,
-					fixtures: buildThemeFixtures(themes, {
-						code: jsTestCode,
-						language: 'js',
-						meta: '',
-						plugins: [pluginShiki({ includeExplanation: true, transformers: [scopesTransformer] })],
-					}),
-				})
-			},
-			{ timeout: 5 * 1000 }
-		)
-
-		test(
 			'Throws an error if the text of a line is changed',
 			async ({ task: { name: testName } }) => {
 				const uppercaseTransformer: ShikiTransformer = {


### PR DESCRIPTION
This adds 2 new options for the shiki plugin:
1. `includeExplanation` is passed on to shiki. It does not change EC's output at all, but might be required by transformers
2. `tokensTransformers` is a list of functions, matching the API of Shiki's `tokens` hook, that can manipulate Shiki's ThemedTokens before they are used to produce EC annotations
  - transformers that edit the underlying text are not supported

For more background, see #234