### PR TITLE
Use Astro helper for hook type

### DIFF
--- a/.changeset/wise-snakes-turn.md
+++ b/.changeset/wise-snakes-turn.md
@@ -2,4 +2,4 @@
 'astro-expressive-code': patch
 ---
 
-Fixes type incompatibility with Astro v4.15
+Fixes type incompatibility with Astro v4.15. Thank you @delucis!

--- a/.changeset/wise-snakes-turn.md
+++ b/.changeset/wise-snakes-turn.md
@@ -1,0 +1,5 @@
+---
+'astro-expressive-code': patch
+---
+
+Fixes type incompatibility with Astro v4.15

--- a/packages/astro-expressive-code/src/vite-plugin.ts
+++ b/packages/astro-expressive-code/src/vite-plugin.ts
@@ -1,4 +1,4 @@
-import type { ViteUserConfig } from 'astro'
+import type { HookParameters, ViteUserConfig } from 'astro'
 import { stableStringify } from 'rehype-expressive-code'
 import { getEcConfigFileUrl } from './ec-config'
 import { PartialAstroConfig, serializePartialAstroConfig } from './astro-config'
@@ -21,7 +21,7 @@ export function vitePluginAstroExpressiveCode({
 	scripts: [string, string][]
 	ecIntegrationOptions: AstroExpressiveCodeOptions
 	astroConfig: PartialAstroConfig
-	command: 'dev' | 'build' | 'preview'
+	command: HookParameters<'astro:config:setup'>['command']
 }): NonNullable<ViteUserConfig['plugins']>[number] {
 	const modules: Record<string, string> = {}
 


### PR DESCRIPTION
In Astro 4.15, the `command` type in the `astro:config:setup` hook was updated to also include `'sync'` as a possibility. This causes a type error when building EC with this version of Astro (see [this ecosystem CI failure](https://github.com/withastro/astro-ecosystem-ci/actions/runs/10627116283)), because EC includes an expectation that `command` does not include `'sync'`.

This PR updates that code to use the `HookParameters` utility type to get the `command` type for the current Astro version. This utility was added in Astro v1.0.0-beta.60 (source PR: https://github.com/withastro/astro/pull/3706), so is safe to use for EC’s peer dependency range of astro@^3.3.0.