### PR TITLE
Replace `pnpm i` with `pnpm add`

### DIFF
--- a/.changeset/tidy-planes-smash.md
+++ b/.changeset/tidy-planes-smash.md
@@ -1,0 +1,5 @@
+---
+'@expressive-code/plugin-frames': patch
+---
+
+replace `pnpm i` with `pnpm add`

--- a/.changeset/tidy-planes-smash.md
+++ b/.changeset/tidy-planes-smash.md
@@ -1,5 +1,0 @@
----
-'@expressive-code/plugin-frames': patch
----
-
-replace `pnpm i` with `pnpm add`

--- a/docs/src/components/PackageManagers.astro
+++ b/docs/src/components/PackageManagers.astro
@@ -22,7 +22,7 @@ const tabContents = [
 	},
 	{
 		label: 'pnpm',
-		code: buildCode(prefix, pkg ? (exec ? `pnpm ${pkg} ${exec}` : `pnpm i ${peer ? '--save-peer ' : ''}${pkg}`) : `pnpm i`),
+		code: buildCode(prefix, pkg ? (exec ? `pnpm ${pkg} ${exec}` : `pnpm add ${peer ? '--save-peer ' : ''}${pkg}`) : `pnpm i`),
 	},
 	{
 		label: 'yarn',

--- a/packages/@expressive-code/plugin-frames/test/copy-button.test.ts
+++ b/packages/@expressive-code/plugin-frames/test/copy-button.test.ts
@@ -6,15 +6,15 @@ import { pluginFrames } from '../src'
 
 const exampleTerminalCode = `
 # Install dev dependencies
-pnpm i --save-dev expressive-code some-other-package yet-another-package
+pnpm add --save-dev expressive-code some-other-package yet-another-package
 
 # And a regular one
-pnpm i one-more-package
+pnpm add one-more-package
 `.trim()
 
 const exampleTerminalCodeWithoutComments = `
-pnpm i --save-dev expressive-code some-other-package yet-another-package
-pnpm i one-more-package
+pnpm add --save-dev expressive-code some-other-package yet-another-package
+pnpm add one-more-package
 `.trim()
 
 describe('Allows removing comments from terminal window frames', async () => {

--- a/packages/@expressive-code/plugin-frames/test/rendering.test.ts
+++ b/packages/@expressive-code/plugin-frames/test/rendering.test.ts
@@ -12,7 +12,7 @@ btn.addEventListener('click', () => console.log('Hello World!'))
 `.trim()
 
 const exampleTerminalCode = `
-pnpm i --save-dev expressive-code some-other-package yet-another-package 
+pnpm add --save-dev expressive-code some-other-package yet-another-package 
 `.trim()
 
 describe('Renders frames around the code', async () => {


### PR DESCRIPTION
The pnpm official documentation recommends using the `add` command instead of `install` when installing new packages as follows:

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

Currently it works the same without any differences, but the document clearly distinguishes these two commands.

This means that you have the flexibility to adapt to changes, such as changing or removing commands in future versions.