### PR TITLE
Make rendered line number `aria-hidden`

### DIFF
--- a/packages/@expressive-code/plugin-line-numbers/src/index.ts
+++ b/packages/@expressive-code/plugin-line-numbers/src/index.ts
@@ -41,7 +41,7 @@ export function pluginLineNumbers(): ExpressiveCodePlugin {
 					addGutterElement({
 						renderPhase: 'earlier',
 						renderLine: ({ codeBlock, lineIndex }) => {
-							return h('div.ln', `${lineIndex + (codeBlock.props.startLineNumber ?? 1)}`)
+							return h('div.ln', { 'aria-hidden': 'true' }, `${lineIndex + (codeBlock.props.startLineNumber ?? 1)}`)
 						},
 						renderPlaceholder: () => h('div.ln'),
 					})


### PR DESCRIPTION
Marking line gutters `aria-hidden` to make some scrapers and RSS readers happy.