### PR TITLE
Add community plugins showcase to docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -99,6 +99,10 @@ export default defineConfig({
 							label: 'Line Numbers',
 							link: '/plugins/line-numbers/',
 						},
+						{
+							label: 'Community Plugins',
+							link: '/plugins/community-plugins/',
+						},
 					],
 				},
 				{

--- a/docs/package.json
+++ b/docs/package.json
@@ -29,6 +29,7 @@
     "mdast-util-to-string": "^4.0.0",
     "sharp": "^0.32.5",
     "starlight-links-validator": "^0.5.1",
+    "starlight-showcases": "^0.2.0",
     "typedoc": "^0.25.4",
     "typedoc-plugin-markdown": "^4.0.0-next.21",
     "typedoc-plugin-missing-exports": "^2.1.0",

--- a/docs/src/content/docs/plugins/community-plugins.mdx
+++ b/docs/src/content/docs/plugins/community-plugins.mdx
@@ -1,0 +1,29 @@
+---
+title: Community Plugins
+---
+
+import { ShowcaseCTA, ShowcaseText } from 'starlight-showcases'
+
+The community-maintained plugins on this page extend Expressive Code to add new behaviors and capabilities.
+
+<ShowcaseCTA>Have you built an Expressive Code plugin? [Open a PR](https://github.com/expressive-code/expressive-code) to add it to the list!</ShowcaseCTA>
+
+<ShowcaseText
+	entries={[
+		{
+			href: 'https://delucis.github.io/expressive-code-color-chips/',
+			title: 'expressive-code-color-chips',
+			description: 'Add color previews to your CSS code examples.',
+		},
+		{
+			href: 'https://github.com/FujoWebDev/fujocoded-plugins/tree/main/expressive-code-caption',
+			title: '@fujocoded/expressive-code-caption',
+			description: 'Add figure captions to codeblocks.',
+		},
+		{
+			href: 'https://github.com/FujoWebDev/fujocoded-plugins/tree/main/expressive-code-output',
+			title: '@fujocoded/expressive-code-output',
+			description: 'Separate code from its output within a codeblock.',
+		},
+	]}
+/>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       starlight-links-validator:
         specifier: ^0.5.1
         version: 0.5.1(@astrojs/starlight@0.26.1)(astro@4.14.3)
+      starlight-showcases:
+        specifier: ^0.2.0
+        version: 0.2.0(@astrojs/starlight@0.26.1)(astro@4.14.3)
       typedoc:
         specifier: ^0.25.4
         version: 0.25.4(typescript@5.2.2)
@@ -582,6 +585,30 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.20
+
+  /@astro-community/astro-embed-twitter@0.5.7(astro@4.14.3):
+    resolution: {integrity: sha512-/IMaFWKFMP62RCrLXWdQ/xXLVguaqE6sUcC4RDIg0yZ0yg3FCGcyVluijo+TDnB3PyJhgcq9jz6b1hNgZxIiYw==}
+    peerDependencies:
+      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
+    dependencies:
+      '@astro-community/astro-embed-utils': 0.1.3
+      astro: 4.14.3(@types/node@18.15.11)(typescript@5.2.2)
+    dev: false
+
+  /@astro-community/astro-embed-utils@0.1.3:
+    resolution: {integrity: sha512-eiMO+vfCdE9GtW6qE7X5Xl6YCKZDCoXJEWqRofQcoC3GHjqN2/WhJlnaxNVRq3demSO03UNtho57Em5p7o7AOA==}
+    dependencies:
+      linkedom: 0.14.26
+    dev: false
+
+  /@astro-community/astro-embed-youtube@0.5.5(astro@4.14.3):
+    resolution: {integrity: sha512-pG9uYjyZB1kpW8Ljy/H1Klof2txVXLwQmyoG4XWblZyt9eqFlaa65MdzL7UKzzqdoOsn64TN+Q+zPbx0HJhP4Q==}
+    peerDependencies:
+      astro: ^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta
+    dependencies:
+      astro: 4.14.3(@types/node@18.15.11)(typescript@5.2.2)
+      lite-youtube-embed: 0.3.3
+    dev: false
 
   /@astrojs/cloudflare@10.0.2(astro@4.5.2):
     resolution: {integrity: sha512-csRatKPw8B/sL5Xz+UZ8Eh5WahSiSQbRNUQx4tYrZaEjUCV0BA14uYaV0rZyTAe62fZlFOqHbpfq0AeZRQWj/w==}
@@ -5392,8 +5419,23 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
   /css-selector-parser@3.0.5:
     resolution: {integrity: sha512-3itoDFbKUNx1eKmVpYMFyqKX04Ww9osZ+dLgrk6GEv6KMVeXUhUnp4I5X+evw+u3ZxVU6RFXSSRxlTeMh8bA+g==}
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
     dev: false
 
   /css.escape@1.5.1:
@@ -5404,6 +5446,10 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  /cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+    dev: false
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -5717,6 +5763,33 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
+
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+    dev: false
 
   /dset@3.1.3:
     resolution: {integrity: sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==}
@@ -7661,6 +7734,15 @@ packages:
     resolution: {integrity: sha512-KlClZ3/Qy5UgvpvVvDomGhnQhNWH5INE8GwvSIQ9CWt1K0zbbXrl7eN5bWaafOZgtmO3jMPwUqmrmEwinhPq1w==}
     dev: false
 
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
+    dev: false
+
   /http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -8283,11 +8365,25 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
+  /linkedom@0.14.26:
+    resolution: {integrity: sha512-mK6TrydfFA7phrnp+1j57ycBwFI5bGSW6YXlw9acHoqF+mP/y+FooEYYyniOt5Ot57FSKB3iwmnuQ1UUyNLm5A==}
+    dependencies:
+      css-select: 5.1.0
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 8.0.2
+      uhyphen: 0.2.0
+    dev: false
+
   /linkify-it@4.0.1:
     resolution: {integrity: sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==}
     dependencies:
       uc.micro: 1.0.6
     dev: true
+
+  /lite-youtube-embed@0.3.3:
+    resolution: {integrity: sha512-gFfVVnj6NRjxVfJKo3qoLtpi0v5mn3AcR4eKD45wrxQuxzveFJUb+7Cr6uV6n+DjO8X3p0UzPPquhGt0H/y+NA==}
+    dev: false
 
   /load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -11614,6 +11710,19 @@ packages:
       unist-util-visit: 5.0.0
     dev: false
 
+  /starlight-showcases@0.2.0(@astrojs/starlight@0.26.1)(astro@4.14.3):
+    resolution: {integrity: sha512-YWJuTqArkUdVJV85VKZJ0BvKCQRu1SKtH/Cr5t6G/oIfI4IptWc92E7BmiuNnpuQ2U7TczTRidCYurPrbgQQVA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.23.0'
+    dependencies:
+      '@astro-community/astro-embed-twitter': 0.5.7(astro@4.14.3)
+      '@astro-community/astro-embed-youtube': 0.5.5(astro@4.14.3)
+      '@astrojs/starlight': 0.26.1(astro@4.14.3)
+    transitivePeerDependencies:
+      - astro
+    dev: false
+
   /std-env@3.4.3:
     resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
     dev: true
@@ -12460,6 +12569,10 @@ packages:
   /ufo@1.3.1:
     resolution: {integrity: sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==}
     dev: true
+
+  /uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
This PR adds a new “Community Plugins” page to the Expressive Code docs to showcase plugins and help users find more possibilities.

I added HiDeoo’s [`starlight-showcases`](https://starlight-showcases.vercel.app/) package to simplify adding this page, but can also do it with plain Starlight components if you prefer. The main benefit of the package is it abstracts away the grid and link cards so that maintaining the page only involves updating data.

Direct link to the page deploy preview: https://deploy-preview-259--expressive-code.netlify.app/plugins/community-plugins/