### PR TITLE
Fix `cssVarReplacements` desync by moving it into `PluginStyleSettings`

### DIFF
--- a/.changeset/tender-camels-smoke.md
+++ b/.changeset/tender-camels-smoke.md
@@ -1,0 +1,6 @@
+---
+'@expressive-code/plugin-collapsible-sections': patch
+'@expressive-code/core': patch
+---
+
+Fixes invalid CSS file links when using the `Code` component together with `plugin-collapsible-sections` and `pnpm`. Thank you @simonporter007 and @ayZagen for the report!

--- a/docs/scripts/lib/changelogs.ts
+++ b/docs/scripts/lib/changelogs.ts
@@ -35,7 +35,7 @@ export function loadChangelog(path: string): Changelog {
 	let markdown = readFileSync(path, 'utf8')
 
 	// Convert GitHub usernames in "Thanks ..." sentences to links
-	markdown = markdown.replace(/(Thank[^.!]*? )@([a-z0-9-]+)([\s,.!])/gi, '$1[@$2](https://github.com/$2)$3')
+	markdown = markdown.replace(/(?<=Thank[^.!]*? )@([a-z0-9-]+)(?=[\s,.!])/gi, '[@$1](https://github.com/$1)')
 
 	const ast = fromMarkdown(markdown)
 	// const lines = readFileSync(path, 'utf8')

--- a/docs/src/content/docs/key-features/frames.mdx
+++ b/docs/src/content/docs/key-features/frames.mdx
@@ -140,7 +140,7 @@ The frames plugin adds multiple props to the `<Code>` component that allow direc
 #### frame
 
 <PropertySignature>
-- Type: `"code"` \| `"terminal"` \| `"none"` \| `"auto"`
+- Type: `"terminal"` \| `"code"` \| `"none"` \| `"auto"`
 - Default: `auto`
 </PropertySignature>
 

--- a/docs/src/content/docs/reference/plugin-api.mdx
+++ b/docs/src/content/docs/reference/plugin-api.mdx
@@ -82,6 +82,9 @@ cssVar method to get a CSS variable reference to any style setting.
 
 If CSS variables should not be generated for some of your style settings, you can exclude them using the `cssVarExclusions` property of the object passed to the constructor.
 
+If you want to provide descriptive names for your style settings, but keep the generated CSS variable names short, you can pass an array of search and replace string pairs to the
+`cssVarReplacements` property of the object passed to the constructor. The replacements will be applied to all generated CSS variable names.
+
 ### Example
 
 ```ts
@@ -133,6 +136,7 @@ framesStyleSettings.defaultValues.frames.titleBarForeground // ({ theme }) => th
 | `options` | `Object` |
 | `options.defaultValues` | `Partial`\<[`UnresolvedStyleSettings`](/reference/plugin-api/#unresolvedstylesettings)\> |
 | `options.cssVarExclusions`? | [`StyleSettingPath`](/reference/plugin-api/#stylesettingpath)[] |
+| `options.cssVarReplacements`? | \[`string`, `string`\][] |
 
 ### Properties
 
@@ -140,6 +144,12 @@ framesStyleSettings.defaultValues.frames.titleBarForeground // ({ theme }) => th
 
 <PropertySignature>
 - Type: **readonly** [`StyleSettingPath`](/reference/plugin-api/#stylesettingpath)[]
+</PropertySignature>
+
+#### cssVarReplacements
+
+<PropertySignature>
+- Type: **readonly** \[`string`, `string`\][]
 </PropertySignature>
 
 #### defaultValues

--- a/docs/src/content/docs/releases.md
+++ b/docs/src/content/docs/releases.md
@@ -7,6 +7,48 @@ This page combines all release notes of the Expressive Code monorepo.
 You can find the source changelogs on GitHub in the subfolders of
 [`packages`](https://github.com/expressive-code/expressive-code/tree/main/packages).
 
+## 0.38.0
+
+- Updates Shiki to the latest version (1.22.2).
+
+- Adds config merging functionality to `astro-expressive-code`, which allows using `ec.config.mjs` together with other configuration sources like the Astro / Starlight config or Starlight themes.
+
+  Options defined in `ec.config.mjs` have the highest priority and will override any corresponding values coming from other configuration sources.
+
+  For the following object options, a deep merge is performed instead of a simple override:
+
+  - `defaultProps`
+  - `frames`
+  - `shiki`
+  - `styleOverrides`
+
+  The following array options are concatenated instead of being replaced:
+
+  - `shiki.langs`
+
+- Adds new config option `shiki.injectLangsIntoNestedCodeBlocks`.
+
+  By default, the additional languages defined in the `shiki.langs` option are only available in top-level code blocks contained directly in their parent Markdown or MDX document.
+
+  Setting the new `shiki.injectLangsIntoNestedCodeBlocks` option to `true` also enables syntax highlighting when a fenced code block using one of your additional `langs` is nested inside an outer `markdown`, `md` or `mdx` code block. Example:
+
+  `````md
+  ````md
+  This top-level Markdown code block contains a nested `my-custom-lang` code block:
+
+  ```my-custom-lang
+  This nested code block will only be highlighted using `my-custom-lang`
+  if `injectLangsIntoNestedCodeBlocks` is enabled.
+  ```
+  ````
+  `````
+
+- Allows overriding bundled languages using the `shiki.langs` option. Thank you [@Robot-Inventor](https://github.com/Robot-Inventor)!
+
+  The Shiki language loading logic has been improved to allow passing custom versions of bundled languages without the risk of them being overwritten by the bundled version later.
+
+- Adds on-demand Shiki language loading to speed up dev server startup and build times while simultaneously decreasing memory usage. Thank you, [@fweth](https://github.com/fweth)!
+
 ## 0.37.1
 
 - Adds `aria-hidden="true"` to line numbers to prevent them from being read out loud and interrupting the flow of the code. Thank you [@Yesterday17](https://github.com/Yesterday17)!
@@ -39,7 +81,7 @@ You can find the source changelogs on GitHub in the subfolders of
 
 ## 0.35.5
 
-- Fixes a Vite warning about `emitFile()` usage. Thank you [@evadecker](https://github.com/evadecker) and @alexanderniebuhr!
+- Fixes a Vite warning about `emitFile()` usage. Thank you [@evadecker](https://github.com/evadecker) and [@alexanderniebuhr](https://github.com/alexanderniebuhr)!
 
   To avoid this warning from being incorrectly triggered, the Vite plugin internally used by `astro-expressive-code` has now been split into two separate plugins, making sure that `emitFile` is only seen by Vite during build.
 
@@ -109,7 +151,7 @@ You can find the source changelogs on GitHub in the subfolders of
 
   To achieve this, the code responsible for loading the optional `ec.config.mjs` file was replaced with a new version that no longer requires any Node.js-specific functionality.
 
-- Makes Expressive Code compatible with Bun. Thank you [@tylergannon](https://github.com/tylergannon) for the fix and @richardguerre for the report!
+- Makes Expressive Code compatible with Bun. Thank you [@tylergannon](https://github.com/tylergannon) for the fix and [@richardguerre](https://github.com/richardguerre) for the report!
 
   This fixes the error `msg.match is not a function` that was thrown when trying to use Expressive Code with Bun.
 

--- a/packages/@expressive-code/core/src/common/engine.ts
+++ b/packages/@expressive-code/core/src/common/engine.ts
@@ -3,7 +3,7 @@ import githubLight from 'shiki/themes/github-light.mjs'
 import { ExpressiveCodePlugin, ResolverContext } from './plugin'
 import { renderGroup, RenderInput, RenderOptions } from '../internal/render-group'
 import { ExpressiveCodeTheme } from './theme'
-import { PluginStyles, scopeAndMinifyNestedCss, processPluginStyles, wrapInCascadeLayer } from '../internal/css'
+import { PluginStyles, scopeAndMinifyNestedCss, processPluginStyles, wrapInCascadeLayer, cssVarReplacements } from '../internal/css'
 import { getCoreBaseStyles, getCoreThemeStyles } from '../internal/core-styles'
 import { StyleVariant, resolveStyleVariants } from './style-variants'
 import { StyleOverrides, StyleSettingPath, getCssVarName } from './style-settings'
@@ -249,6 +249,13 @@ export class ExpressiveCodeEngine implements ResolvedExpressiveCodeEngineConfig 
 		this.defaultProps = config.defaultProps || {}
 		this.plugins = [...corePlugins, ...(config.plugins?.flat() || [])]
 		this.logger = new ExpressiveCodeLogger(config.logger)
+
+		// Ensure cssVarReplacements contributed by plugins are globally available
+		this.plugins.forEach((plugin) => {
+			plugin.styleSettings?.cssVarReplacements?.forEach(([search, replace]) => {
+				cssVarReplacements.set(search, replace)
+			})
+		})
 
 		// Allow customizing the loaded themes
 		this.themes = this.themes.map((theme, styleVariantIndex) => {

--- a/packages/@expressive-code/core/src/common/plugin-style-settings.ts
+++ b/packages/@expressive-code/core/src/common/plugin-style-settings.ts
@@ -22,6 +22,11 @@ import { UnresolvedStyleSettings, StyleSettingPath } from './style-settings'
  * If CSS variables should not be generated for some of your style settings, you can exclude them
  * using the `cssVarExclusions` property of the object passed to the constructor.
  *
+ * If you want to provide descriptive names for your style settings, but keep the generated
+ * CSS variable names short, you can pass an array of search and replace string pairs to the
+ * `cssVarReplacements` property of the object passed to the constructor. The replacements
+ * will be applied to all generated CSS variable names.
+ *
  * @example
  * // When using TypeScript: Declare the types of your style settings
  * interface FramesStyleSettings {
@@ -60,9 +65,19 @@ import { UnresolvedStyleSettings, StyleSettingPath } from './style-settings'
 export class PluginStyleSettings {
 	readonly defaultValues: Partial<UnresolvedStyleSettings>
 	readonly cssVarExclusions: StyleSettingPath[]
+	readonly cssVarReplacements: [string, string][]
 
-	constructor({ defaultValues, cssVarExclusions = [] }: { defaultValues: Partial<UnresolvedStyleSettings>; cssVarExclusions?: StyleSettingPath[] | undefined }) {
+	constructor({
+		defaultValues,
+		cssVarExclusions = [],
+		cssVarReplacements = [],
+	}: {
+		defaultValues: Partial<UnresolvedStyleSettings>
+		cssVarExclusions?: StyleSettingPath[] | undefined
+		cssVarReplacements?: [string, string][] | undefined
+	}) {
 		this.defaultValues = defaultValues
 		this.cssVarExclusions = cssVarExclusions
+		this.cssVarReplacements = cssVarReplacements
 	}
 }

--- a/packages/@expressive-code/core/src/common/style-settings.ts
+++ b/packages/@expressive-code/core/src/common/style-settings.ts
@@ -1,4 +1,5 @@
 import { CoreStyleSettings } from '../internal/core-styles'
+import { cssVarReplacements } from '../internal/css'
 import { ExpressiveCodeTheme } from './theme'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -53,50 +54,6 @@ export type StyleOverrides = Partial<{
 }>
 
 export type ResolvedStyleSettingsByPath = Map<StyleSettingPath, string>
-
-/**
- * A map of long terms commonly found in style setting paths to shorter alternatives that are
- * still human-readable. These replacements are automatically applied by {@link getCssVarName}
- * when generating CSS variable names to keep them fairly short.
- *
- * Plugins can add their own replacements to this map by importing this constant and calling
- * `cssVarReplacements.set('myLongTerm', 'myLt')` inside their plugin initialization function.
- */
-export const cssVarReplacements = new Map<string, string>([
-	['background', 'bg'],
-	['foreground', 'fg'],
-	['color', 'col'],
-	['border', 'brd'],
-	['padding', 'pad'],
-	['margin', 'marg'],
-	['radius', 'rad'],
-	['opacity', 'opa'],
-	['width', 'wd'],
-	['height', 'ht'],
-	['weight', 'wg'],
-	['block', 'blk'],
-	['inline', 'inl'],
-	['bottom', 'btm'],
-	['value', 'val'],
-	['active', 'act'],
-	['inactive', 'inact'],
-	['highlight', 'hl'],
-	['selection', 'sel'],
-	['indicator', 'ind'],
-	['shadow', 'shd'],
-	['family', 'fml'],
-	['transform', 'trf'],
-	['decoration', 'dec'],
-	['button', 'btn'],
-	['editor', 'ed'],
-	['terminal', 'trm'],
-	['scrollbar', 'sb'],
-	['toolbar', 'tb'],
-	['gutter', 'gtr'],
-	['titlebar', 'ttb'],
-	['textMarkers', 'tm'],
-	['frames', 'frm'],
-])
 
 /**
  * Generates a CSS variable name for a given style setting path.

--- a/packages/@expressive-code/core/src/index.ts
+++ b/packages/@expressive-code/core/src/index.ts
@@ -17,3 +17,8 @@ export * from './helpers/color-transforms'
 export * from './helpers/i18n'
 export * from './helpers/meta-options'
 export * from './helpers/objects'
+
+import { cssVarReplacements as internalCssVarReplacements } from './internal/css'
+
+/** @deprecated Please pass a `cssVarReplacements` property to the `PluginStyleSettings` constructor instead. */
+export const cssVarReplacements = internalCssVarReplacements

--- a/packages/@expressive-code/core/src/internal/css.ts
+++ b/packages/@expressive-code/core/src/internal/css.ts
@@ -5,6 +5,50 @@ import { escapeRegExp } from './escaping'
 export const groupWrapperElement = 'div'
 export const groupWrapperClassName = 'expressive-code'
 
+/**
+ * A map of long terms commonly found in style setting paths to shorter alternatives that are
+ * still human-readable. These replacements are automatically applied by {@link getCssVarName}
+ * when generating CSS variable names to keep them fairly short.
+ *
+ * Plugins can add their own replacements to this map by adding a `cssVarReplacements` property
+ * to their {@link PluginStyleSettings} object.
+ */
+export const cssVarReplacements = new Map<string, string>([
+	['background', 'bg'],
+	['foreground', 'fg'],
+	['color', 'col'],
+	['border', 'brd'],
+	['padding', 'pad'],
+	['margin', 'marg'],
+	['radius', 'rad'],
+	['opacity', 'opa'],
+	['width', 'wd'],
+	['height', 'ht'],
+	['weight', 'wg'],
+	['block', 'blk'],
+	['inline', 'inl'],
+	['bottom', 'btm'],
+	['value', 'val'],
+	['active', 'act'],
+	['inactive', 'inact'],
+	['highlight', 'hl'],
+	['selection', 'sel'],
+	['indicator', 'ind'],
+	['shadow', 'shd'],
+	['family', 'fml'],
+	['transform', 'trf'],
+	['decoration', 'dec'],
+	['button', 'btn'],
+	['editor', 'ed'],
+	['terminal', 'trm'],
+	['scrollbar', 'sb'],
+	['toolbar', 'tb'],
+	['gutter', 'gtr'],
+	['titlebar', 'ttb'],
+	['textMarkers', 'tm'],
+	['frames', 'frm'],
+])
+
 const preprocessor = postcss([
 	// Prevent top-level selectors that are already scoped from being scoped twice
 	(root: Root) => {

--- a/packages/@expressive-code/plugin-collapsible-sections/src/index.ts
+++ b/packages/@expressive-code/plugin-collapsible-sections/src/index.ts
@@ -1,4 +1,4 @@
-import { AttachedPluginData, ExpressiveCodePlugin, PluginTexts, cssVarReplacements } from '@expressive-code/core'
+import { AttachedPluginData, ExpressiveCodePlugin, PluginTexts } from '@expressive-code/core'
 import { select } from '@expressive-code/core/hast'
 import { Section, parseSections } from './utils'
 import { sectionizeAst } from './ast'
@@ -39,7 +39,6 @@ pluginCollapsibleSectionsTexts.addLocale('de', {
 })
 
 export function pluginCollapsibleSections(): ExpressiveCodePlugin {
-	cssVarReplacements.set('collapsibleSections', 'cs')
 	return {
 		name: 'Collapsible sections',
 		styleSettings: collapsibleSectionsStyleSettings,

--- a/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
+++ b/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
@@ -96,6 +96,7 @@ export const collapsibleSectionsStyleSettings = new PluginStyleSettings({
 			openBorderColor: 'transparent',
 		},
 	},
+	cssVarReplacements: [['collapsibleSections', 'cs']],
 })
 
 export function getCollapsibleSectionsBaseStyles({ cssVar }: ResolverContext) {


### PR DESCRIPTION
Fixes #222.
Fixes #264.

This fixes invalid CSS file links when using the `Code` component together with `plugin-collapsible-sections` and `pnpm`. Due to the module resolution logic when using `pnpm`, the `Code` component was not able to access CSS variable replacements defined by the collapsible sections plugin.