### PR TITLE
Fix `getBlockLocale` and `tabWidth` differences between `<Code>` and rehype

### DIFF
--- a/.changeset/soft-frogs-sit.md
+++ b/.changeset/soft-frogs-sit.md
@@ -1,0 +1,10 @@
+---
+'rehype-expressive-code': patch
+'astro-expressive-code': patch
+---
+
+Fixes an issue where the optional `getBlockLocale` callback function was not called when using the `<Code>` component. Thank you @HiDeoo!
+
+As the parent document's source file path is not available from an Astro component, the `file` property passed to the `getBlockLocale` callback function now contains an additional `url` property that will be set to the value of `Astro.url` in this case.
+
+When determining the locale of a code block, it is recommended to use this new property first, and only fall back to the existing `path` and `cwd` properties if `url` is undefined.

--- a/.changeset/twenty-coats-design.md
+++ b/.changeset/twenty-coats-design.md
@@ -1,0 +1,5 @@
+---
+'astro-expressive-code': patch
+---
+
+Fixes an issue where the `tabWidth` setting was not applied when using the `<Code>` component. Thank you @mrchantey!

--- a/packages/astro-expressive-code/components/Code.astro
+++ b/packages/astro-expressive-code/components/Code.astro
@@ -1,8 +1,9 @@
 ---
+import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument } from 'rehype-expressive-code'
 import { addClassName, toHtml } from 'rehype-expressive-code/hast'
 import { getPageData } from './page-data'
 import { getRenderer } from './renderer'
-import type { CodeProps as Props, MarkerValueType } from './types'
+import type { CodeProps as Props } from './types'
 
 function formatMessage(...messageParts: string[]) {
 	return messageParts.map((part) => part.replace(/\s+/g, ' ')).join('\n\n')
@@ -34,18 +35,39 @@ async function renderToHtml() {
 
 	const renderer = await getRenderer()
 
-	const { renderedGroupAst } = await renderer.ec.render({
+	// Normalize the code coming from the `code` prop
+	const tabWidth = renderer.tabWidth ?? 2
+	if (tabWidth > 0) code = code.replace(/\t/g, ' '.repeat(tabWidth))
+
+	// Build the ExpressiveCodeBlockOptions object that we will pass to the renderer
+	const input: ExpressiveCodeBlockOptions = {
 		code,
 		language: lang,
 		meta,
 		locale,
 		parentDocument: {
+			sourceFilePath: Astro.request.url,
 			positionInDocument: {
 				groupIndex,
 			},
 		},
 		props,
-	})
+	}
+
+	// Allow using the same function as `rehype-expressive-code` to auto-detect the locale
+	// if none was provided through the `locale` prop
+	if (!locale && renderer.getBlockLocale) {
+		const file: RehypeExpressiveCodeDocument = {
+			url: Astro.url,
+			// Provide default values for all required properties we don't have access to
+			path: '',
+			cwd: '/',
+			data: {},
+		}
+		input.locale = await renderer.getBlockLocale({ input, file })
+	}
+
+	const { renderedGroupAst } = await renderer.ec.render(input)
 
 	if (renderedGroupAst?.type === 'element') {
 		if (className) {

--- a/packages/astro-expressive-code/components/renderer.ts
+++ b/packages/astro-expressive-code/components/renderer.ts
@@ -30,8 +30,15 @@ async function createRenderer() {
 		throw new Error(`Failed to preprocess Expressive Code config for the Code component: ${msg}`, { cause: error })
 	}
 
-	return await createAstroRenderer({
+	const astroRenderer = await createAstroRenderer({
 		astroConfig,
 		ecConfig: mergedEcConfig,
 	})
+	return {
+		...astroRenderer,
+		// Also return any config options that are normally processed by `rehype-expressive-code`
+		// and need to be processed by `astro-expressive-code` when using the `Code` component
+		tabWidth: mergedEcConfig.tabWidth,
+		getBlockLocale: mergedEcConfig.getBlockLocale,
+	}
 }


### PR DESCRIPTION
Fixes #216.

Also fixes an issue where the optional `getBlockLocale` callback function was not called when using the `<Code>` component.