### PR TITLE
Remove first line end padding if copy button is disabled

### DIFF
--- a/.changeset/cool-spies-applaud.md
+++ b/.changeset/cool-spies-applaud.md
@@ -1,0 +1,9 @@
+---
+'@expressive-code/plugin-frames': patch
+'@expressive-code/core': patch
+'astro-expressive-code': patch
+'expressive-code': patch
+'rehype-expressive-code': patch
+---
+
+Removes unnecessary end padding from the first code line if the copy to clipboard button is disabled. Thank you @goulvenclech!

--- a/packages/@expressive-code/core/src/internal/core-styles.ts
+++ b/packages/@expressive-code/core/src/internal/core-styles.ts
@@ -366,11 +366,6 @@ export function getCoreBaseStyles({
 			}
 		}
 
-		/* Increase end padding of the first line for the copy button */
-		:nth-child(1 of .${codeLineClass}) .code {
-			padding-inline-end: calc(2rem + ${cssVar('codePaddingInline')});
-		}
-
 		/* Common style to hide elements from screen readers */
 		.sr-only {
 			position: absolute;

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -1,5 +1,6 @@
-import { PluginStyleSettings, ResolverContext, multiplyAlpha, onBackground, setLuminance } from '@expressive-code/core'
-import { PluginFramesOptions } from '.'
+import type { ResolverContext } from '@expressive-code/core'
+import { PluginStyleSettings, codeLineClass, multiplyAlpha, onBackground, setLuminance } from '@expressive-code/core'
+import type { PluginFramesOptions } from '.'
 
 export interface FramesStyleSettings {
 	/**
@@ -547,6 +548,11 @@ export function getFramesBaseStyles({ cssVar }: ResolverContext, options: Plugin
 		.frame .copy .feedback.show ~ button:not(:hover) {
 			opacity: 0.75;
 		}
+	}
+	
+	/* Increase end padding of the first line for the copy button */
+	:nth-child(1 of .${codeLineClass}) .code {
+		padding-inline-end: calc(2rem + ${cssVar('codePaddingInline')});
 	}`
 
 	const styles = [


### PR DESCRIPTION
Fixes #292. This moves the CSS rule that was previously a part of the core package into `plugin-frames` so that it can be conditionally included only when the copy to clipboard button is enabled.

The rule is meant to ensure that code overlapped by the copy button can be scrolled to make it visible, so it's unnecessary if the button is disabled.