### PR TITLE
Exclude all SVGs and children from style reset

### DIFF
--- a/.changeset/rare-monkeys-sell.md
+++ b/.changeset/rare-monkeys-sell.md
@@ -1,0 +1,8 @@
+---
+'@expressive-code/core': patch
+'astro-expressive-code': patch
+'expressive-code': patch
+'rehype-expressive-code': patch
+---
+
+Prevents the default [style reset](https://expressive-code.com/reference/configuration/#usestylereset) from interfering with more complex SVGs inside Expressive Code blocks. Now, not only `path` elements, but all SVGs and their contents are excluded from the reset. Thank you @xt0rted!

--- a/packages/@expressive-code/core/src/internal/core-styles.ts
+++ b/packages/@expressive-code/core/src/internal/core-styles.ts
@@ -238,7 +238,7 @@ export function getCoreBaseStyles({
 		text-size-adjust: none;
 		-webkit-text-size-adjust: none;
 
-		*:not(path) {
+		*:not(:is(svg, svg *)) {
 			${useStyleReset ? 'all: revert;' : ''}
 			box-sizing: border-box;
 		}


### PR DESCRIPTION
Fixes #304. Now, not only `path` elements, but all SVGs and their contents are excluded from the reset.