### PR TITLE
Add `preventUnitlessValues` property to `PluginStyleSettings`

### DIFF
--- a/.changeset/famous-drinks-taste.md
+++ b/.changeset/famous-drinks-taste.md
@@ -1,0 +1,7 @@
+---
+'@expressive-code/plugin-collapsible-sections': minor
+'@expressive-code/plugin-text-markers': minor
+'@expressive-code/plugin-frames': minor
+---
+
+Uses the new `preventUnitlessValues` property of `PluginStyleSettings` to make style calculations in the plugins "Collapsible Sections", "Frames" and "Text Markers" more robust.

--- a/.changeset/heavy-jokes-doubt.md
+++ b/.changeset/heavy-jokes-doubt.md
@@ -1,0 +1,10 @@
+---
+'@expressive-code/core': minor
+'astro-expressive-code': minor
+'expressive-code': minor
+'rehype-expressive-code': minor
+---
+
+Adds new `preventUnitlessValues` property to `PluginStyleSettings`.
+
+Plugins can set this property to an array of style setting paths to prevent unitless values for specific style settings. If the user passes a unitless value to one of these settings, the engine will automatically add `px` to the value. This is recommended for settings used in CSS calculations which would otherwise break if a unitless value is passed.

--- a/.changeset/heavy-jokes-doubt.md
+++ b/.changeset/heavy-jokes-doubt.md
@@ -5,6 +5,6 @@
 'rehype-expressive-code': minor
 ---
 
-Adds new `preventUnitlessValues` property to `PluginStyleSettings`.
+Adds new `preventUnitlessValues` property to `PluginStyleSettings`. Thank you @RantingHuman!
 
 Plugins can set this property to an array of style setting paths to prevent unitless values for specific style settings. If the user passes a unitless value to one of these settings, the engine will automatically add `px` to the value. This is recommended for settings used in CSS calculations which would otherwise break if a unitless value is passed.

--- a/docs/src/content/docs/reference/plugin-api.mdx
+++ b/docs/src/content/docs/reference/plugin-api.mdx
@@ -85,6 +85,9 @@ If CSS variables should not be generated for some of your style settings, you ca
 If you want to provide descriptive names for your style settings, but keep the generated CSS variable names short, you can pass an array of search and replace string pairs to the
 `cssVarReplacements` property of the object passed to the constructor. The replacements will be applied to all generated CSS variable names.
 
+If you want to prevent unitless values for specific style settings (e.g. because you intend to use them in CSS calculations), you can pass an array of style setting paths to the
+`preventUnitlessValues` property of the object passed to the constructor. If the user passes a unitless value to one of these settings, the engine will automatically add `px` to the value.
+
 ### Example
 
 ```ts
@@ -137,6 +140,7 @@ framesStyleSettings.defaultValues.frames.titleBarForeground // ({ theme }) => th
 | `options.defaultValues` | `Partial`\<[`UnresolvedStyleSettings`](/reference/plugin-api/#unresolvedstylesettings)\> |
 | `options.cssVarExclusions`? | [`StyleSettingPath`](/reference/plugin-api/#stylesettingpath)[] |
 | `options.cssVarReplacements`? | \[`string`, `string`\][] |
+| `options.preventUnitlessValues`? | [`StyleSettingPath`](/reference/plugin-api/#stylesettingpath)[] |
 
 ### Properties
 
@@ -156,6 +160,12 @@ framesStyleSettings.defaultValues.frames.titleBarForeground // ({ theme }) => th
 
 <PropertySignature>
 - Type: **readonly** `Partial`\<[`UnresolvedStyleSettings`](/reference/plugin-api/#unresolvedstylesettings)\>
+</PropertySignature>
+
+#### preventUnitlessValues
+
+<PropertySignature>
+- Type: **readonly** [`StyleSettingPath`](/reference/plugin-api/#stylesettingpath)[]
 </PropertySignature>
 
 ## AttachedPluginData

--- a/packages/@expressive-code/core/src/common/plugin-style-settings.ts
+++ b/packages/@expressive-code/core/src/common/plugin-style-settings.ts
@@ -27,6 +27,11 @@ import { UnresolvedStyleSettings, StyleSettingPath } from './style-settings'
  * `cssVarReplacements` property of the object passed to the constructor. The replacements
  * will be applied to all generated CSS variable names.
  *
+ * If you want to prevent unitless values for specific style settings (e.g. because you intend
+ * to use them in CSS calculations), you can pass an array of style setting paths to the
+ * `preventUnitlessValues` property of the object passed to the constructor. If the user passes
+ * a unitless value to one of these settings, the engine will automatically add `px` to the value.
+ *
  * @example
  * // When using TypeScript: Declare the types of your style settings
  * interface FramesStyleSettings {
@@ -66,18 +71,22 @@ export class PluginStyleSettings {
 	readonly defaultValues: Partial<UnresolvedStyleSettings>
 	readonly cssVarExclusions: StyleSettingPath[]
 	readonly cssVarReplacements: [string, string][]
+	readonly preventUnitlessValues: StyleSettingPath[]
 
 	constructor({
 		defaultValues,
 		cssVarExclusions = [],
 		cssVarReplacements = [],
+		preventUnitlessValues = [],
 	}: {
 		defaultValues: Partial<UnresolvedStyleSettings>
 		cssVarExclusions?: StyleSettingPath[] | undefined
 		cssVarReplacements?: [string, string][] | undefined
+		preventUnitlessValues?: StyleSettingPath[] | undefined
 	}) {
 		this.defaultValues = defaultValues
 		this.cssVarExclusions = cssVarExclusions
 		this.cssVarReplacements = cssVarReplacements
+		this.preventUnitlessValues = preventUnitlessValues
 	}
 }

--- a/packages/@expressive-code/core/src/internal/core-styles.ts
+++ b/packages/@expressive-code/core/src/internal/core-styles.ts
@@ -214,6 +214,7 @@ export const coreStyleSettings = new PluginStyleSettings({
 		scrollbarThumbHoverColor: ({ theme, resolveSetting }) =>
 			ensureColorContrastOnBackground(theme.colors['scrollbarSlider.hoverBackground'], resolveSetting('codeBackground'), 2.5, 3.5),
 	} satisfies UnresolvedStyleSettings,
+	preventUnitlessValues: ['borderRadius', 'borderWidth', 'gutterBorderWidth'],
 })
 
 export function getCoreBaseStyles({

--- a/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
+++ b/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
@@ -108,6 +108,7 @@ export const collapsibleSectionsStyleSettings = new PluginStyleSettings({
 		},
 	},
 	cssVarReplacements: [['collapsibleSections', 'cs']],
+	preventUnitlessValues: ['collapsibleSections.closedBorderWidth', 'collapsibleSections.openBorderWidth'],
 })
 
 export function getCollapsibleSectionsBaseStyles({ cssVar }: ResolverContext) {

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -233,6 +233,7 @@ export const framesStyleSettings = new PluginStyleSettings({
 			tooltipSuccessForeground: 'white',
 		},
 	},
+	preventUnitlessValues: ['frames.editorActiveTabIndicatorHeight', 'frames.editorTabBorderRadius'],
 })
 
 export function getFramesBaseStyles({ cssVar }: ResolverContext, options: PluginFramesOptions) {

--- a/packages/@expressive-code/plugin-text-markers/src/styles.ts
+++ b/packages/@expressive-code/plugin-text-markers/src/styles.ts
@@ -234,6 +234,7 @@ export const textMarkersStyleSettings = new PluginStyleSettings({
 		'textMarkers.indicatorLuminance',
 		'textMarkers.indicatorOpacity',
 	],
+	preventUnitlessValues: ['textMarkers.lineMarkerLabelPaddingInline', 'textMarkers.lineMarkerAccentWidth'],
 })
 
 export function getTextMarkersBaseStyles({ cssVar }: ResolverContext) {


### PR DESCRIPTION
Fixes #311 by adding new `preventUnitlessValues` property to `PluginStyleSettings` and using it in core and plugins "Collapsible Sections", "Frames" and "Text Markers".