### PR TITLE
Allow customizing SVG icons of frames & collapsible sections

### DIFF
--- a/.changeset/cuddly-drinks-doubt.md
+++ b/.changeset/cuddly-drinks-doubt.md
@@ -1,0 +1,12 @@
+---
+'@expressive-code/plugin-collapsible-sections': minor
+'@expressive-code/plugin-frames': minor
+'@expressive-code/core': minor
+'astro-expressive-code': minor
+'expressive-code': minor
+'rehype-expressive-code': minor
+---
+
+Adds new `createInlineSvgUrl` export that creates an inline SVG image data URL from the given contents of an SVG file.
+
+You can use it to embed SVG images directly into a plugin's styles or HAST, or pass it to an existing `styleOverrides` icon setting.

--- a/.changeset/fair-games-hunt.md
+++ b/.changeset/fair-games-hunt.md
@@ -1,0 +1,7 @@
+---
+'@expressive-code/plugin-collapsible-sections': minor
+---
+
+Adds the following new `styleOverrides` settings:
+
+- `collapsibleSections.expandIcon` and `collapsibleSections.collapseIcon`: Allows overriding the SVG icons used for the expand/collapse buttons.

--- a/.changeset/silver-hounds-hear.md
+++ b/.changeset/silver-hounds-hear.md
@@ -1,0 +1,11 @@
+---
+'@expressive-code/plugin-frames': minor
+'astro-expressive-code': minor
+'expressive-code': minor
+'rehype-expressive-code': minor
+---
+
+Adds the following new `styleOverrides` settings:
+
+- `frames.copyIcon`: Allows overriding the SVG icon used for the copy button.
+- `frames.terminalIcon`: Allows overriding the SVG icon used for the terminal window frame. Defaults to three dots in the top left corner.

--- a/docs/scripts/api-reference.ts
+++ b/docs/scripts/api-reference.ts
@@ -21,7 +21,7 @@ const sourceFiles: PartialConfig = {
 	exclude: ['**/coverage/**/*', '**/node_modules/**/*', '**/dist/**/*', '**/test/**/*'],
 	skipErrorChecking: true,
 	tsconfig: '../tsconfig.base.json',
-	useTsLinkResolution: false,
+	useTsLinkResolution: true,
 }
 
 const { outputPath } = await generateTypeDoc(sourceFiles)

--- a/docs/scripts/typedoc/templates/reference/core-api.mdx
+++ b/docs/scripts/typedoc/templates/reference/core-api.mdx
@@ -263,6 +263,11 @@ headingLevel: 3
 ````
 
 ````yml include
+name: "CreateInlineSvgUrlOptions"
+headingLevel: 3
+````
+
+````yml include
 name: "ExpressiveCodeInlineRange"
 headingLevel: 3
 ````

--- a/docs/scripts/typedoc/templates/reference/core-api.mdx
+++ b/docs/scripts/typedoc/templates/reference/core-api.mdx
@@ -10,6 +10,8 @@ headingLevel: 3
 replacements:
 - search: '/api/expressive-code/core/interfaces/ExpressiveCodeEngineConfig/'
   replace: '/reference/configuration/'
+- search: '/api/expressive-code/interfaces/ExpressiveCodeConfig/'
+  replace: '/reference/configuration/'
 editSections:
 - path: "Properties"
   replaceWith: |
@@ -150,6 +152,92 @@ editSections:
     All config options that can be passed to the constructor are also available on the instance as read-only properties.
     
     See [`InlineStyleAnnotationOptions`](#inlinestyleannotationoptions) for the entire list.
+````
+
+## Asset functions
+
+````yml include
+name: "createInlineSvgUrl"
+headingLevel: 3
+````
+
+## Color analysis functions
+
+````yml include
+name: "getColorContrast"
+headingLevel: 3
+````
+
+````yml include
+name: "getColorContrastOnBackground"
+headingLevel: 3
+````
+
+````yml include
+name: "getFirstStaticColor"
+headingLevel: 3
+````
+
+````yml include
+name: "getLuminance"
+headingLevel: 3
+````
+
+````yml include
+name: "getStaticBackgroundColor"
+headingLevel: 3
+````
+
+## Color manipulation functions
+
+````yml include
+name: "changeAlphaToReachColorContrast"
+headingLevel: 3
+````
+
+````yml include
+name: "changeLuminanceToReachColorContrast"
+headingLevel: 3
+````
+
+````yml include
+name: "darken"
+headingLevel: 3
+````
+
+````yml include
+name: "ensureColorContrastOnBackground"
+headingLevel: 3
+````
+
+````yml include
+name: "lighten"
+headingLevel: 3
+````
+
+````yml include
+name: "mix"
+headingLevel: 3
+````
+
+````yml include
+name: "multiplyAlpha"
+headingLevel: 3
+````
+
+````yml include
+name: "onBackground"
+headingLevel: 3
+````
+
+````yml include
+name: "setAlpha"
+headingLevel: 3
+````
+
+````yml include
+name: "setLuminance"
+headingLevel: 3
 ````
 
 ## Referenced types

--- a/docs/src/content/docs/key-features/frames.mdx
+++ b/docs/src/content/docs/key-features/frames.mdx
@@ -219,6 +219,16 @@ If `true`, a "Copy to clipboard" button will be shown for each code block.
 
 This plugin adds a `frames` object to the `styleOverrides` engine config option, allowing you to customize the visual appearance of the rendered frames. The object contains the following properties:
 
+#### copyIcon
+
+<PropertySignature>
+- Type: [UnresolvedStyleValue](/reference/plugin-api/#unresolvedstylevalue)
+</PropertySignature>
+
+An inline SVG URL for the copy to clipboard icon.
+
+Expects a string in the format `url("data:image/svg+xml,...")`, which can be generated from the contents of an SVG file using [createInlineSvgUrl](/reference/core-api/#createinlinesvgurl).
+
 #### editorActiveTabBackground
 
 <PropertySignature>
@@ -429,6 +439,18 @@ The color to use for the shadow of the frame.
 </PropertySignature>
 
 The background color of the terminal window. This color is used for the "terminal" frame type.
+
+#### terminalIcon
+
+<PropertySignature>
+- Type: [UnresolvedStyleValue](/reference/plugin-api/#unresolvedstylevalue)
+</PropertySignature>
+
+An inline SVG URL for the terminal icon.
+
+Expects a string in the format `url("data:image/svg+xml,...")`, which can be generated from the contents of an SVG file using [createInlineSvgUrl](/reference/core-api/#createinlinesvgurl).
+
+Defaults to three dots in a row.
 
 #### terminalTitlebarBackground
 

--- a/docs/src/content/docs/plugins/collapsible-sections.mdx
+++ b/docs/src/content/docs/plugins/collapsible-sections.mdx
@@ -267,6 +267,26 @@ The block padding of the summary line.
 
 The text color of the section summary line.
 
+#### collapseIcon
+
+<PropertySignature>
+- Type: [UnresolvedStyleValue](/reference/plugin-api/#unresolvedstylevalue)
+</PropertySignature>
+
+An inline SVG URL for the collapse icon.
+
+Expects a string in the format `url("data:image/svg+xml,...")`, which can be generated from the contents of an SVG file using [createInlineSvgUrl](/reference/core-api/#createinlinesvgurl).
+
+#### expandIcon
+
+<PropertySignature>
+- Type: [UnresolvedStyleValue](/reference/plugin-api/#unresolvedstylevalue)
+</PropertySignature>
+
+An inline SVG URL for the expand icon.
+
+Expects a string in the format `url("data:image/svg+xml,...")`, which can be generated from the contents of an SVG file using [createInlineSvgUrl](/reference/core-api/#createinlinesvgurl).
+
 #### openBackgroundColor
 
 <PropertySignature>

--- a/docs/src/content/docs/reference/core-api.mdx
+++ b/docs/src/content/docs/reference/core-api.mdx
@@ -915,6 +915,225 @@ All config options that can be passed to the constructor are also available on t
 See [`InlineStyleAnnotationOptions`](#inlinestyleannotationoptions) for the entire list.
 
 
+## Asset functions
+
+### createInlineSvgUrl
+
+- <code class="function-signature">**createInlineSvgUrl**(svgContents): string</code>
+
+Creates an inline SVG image data URL from the given contents of an SVG file.
+
+You can use it to embed SVG images directly into your plugin's styles or HAST.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `svgContents` | `string` \| `string`[] |
+
+## Color analysis functions
+
+### getColorContrast
+
+- <code class="function-signature">**getColorContrast**(color1, color2): number</code>
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `color1` | `string` |
+| `color2` | `string` |
+
+### getColorContrastOnBackground
+
+- <code class="function-signature">**getColorContrastOnBackground**(input, background): number</code>
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `background` | `string` |
+
+### getFirstStaticColor
+
+- <code class="function-signature">**getFirstStaticColor**(...inputs): undefined \| string</code>
+
+Given any number of input colors, which may include CSS variables with optional fallbacks, returns the first static color.
+
+Returns `undefined` if no parseable static color can be found.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| ...`inputs` | (`undefined` \| `string`)[] |
+
+### getLuminance
+
+- <code class="function-signature">**getLuminance**(input): number</code>
+
+Returns the luminance of a color. Luminance values are between 0 and 1.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+
+### getStaticBackgroundColor
+
+- <code class="function-signature">**getStaticBackgroundColor**(styleVariant): string</code>
+
+Determine a static background color based on the given style variant, trying to resolve fallback values of CSS variables if necessary.
+
+This color is intended to be used for contrast calculations, not as an actual background color.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `styleVariant` | [`StyleVariant`](/reference/plugin-api/#stylevariant) |
+
+## Color manipulation functions
+
+### changeAlphaToReachColorContrast
+
+- <code class="function-signature">**changeAlphaToReachColorContrast**(input, background, minContrast, maxContrast): string</code>
+
+#### Arguments
+
+| Parameter | Type | Default value |
+| :------ | :------ | :------ |
+| `input` | `string` | `undefined` |
+| `background` | `string` | `undefined` |
+| `minContrast` | `number` | `6` |
+| `maxContrast` | `number` | `22` |
+
+### changeLuminanceToReachColorContrast
+
+- <code class="function-signature">**changeLuminanceToReachColorContrast**(input1, input2, minContrast): string</code>
+
+#### Arguments
+
+| Parameter | Type | Default value |
+| :------ | :------ | :------ |
+| `input1` | `string` | `undefined` |
+| `input2` | `string` | `undefined` |
+| `minContrast` | `number` | `6` |
+
+### darken
+
+- <code class="function-signature">**darken**(input, amount): string</code>
+
+Darkens a color by the given amount. Automatically limits the resulting lightness value to the range 0 to 1.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `amount` | `number` |
+
+### ensureColorContrastOnBackground
+
+- <code class="function-signature">**ensureColorContrastOnBackground**(input, background, minContrast, maxContrast): string</code>
+
+Modifies the luminance and/or the alpha value of a color to ensure its color contrast on the given background color is within the given range.
+
+- If the contrast is too low, the luminance is either increased or decreased first, and then the alpha value is increased (if required).
+- If the contrast is too high, only the alpha value is decreased.
+
+If the target contrast cannot be reached, the function will try to get as close as possible.
+
+#### Arguments
+
+| Parameter | Type | Default value |
+| :------ | :------ | :------ |
+| `input` | `string` | `undefined` |
+| `background` | `string` | `undefined` |
+| `minContrast` | `number` | `5.5` |
+| `maxContrast` | `number` | `22` |
+
+### lighten
+
+- <code class="function-signature">**lighten**(input, amount): string</code>
+
+Lightens a color by the given amount. Automatically limits the resulting lightness value to the range 0 to 1.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `amount` | `number` |
+
+### mix
+
+- <code class="function-signature">**mix**(input, mixinInput, amount): string</code>
+
+Mixes the second color into the first color by the given amount. Amount should be between 0 and 1.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `mixinInput` | `string` |
+| `amount` | `number` |
+
+### multiplyAlpha
+
+- <code class="function-signature">**multiplyAlpha**(input, factor): string</code>
+
+Multiplies the existing alpha value of a color with the given factor. Automatically limits the resulting alpha value to the range 0 to 1.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `factor` | `number` |
+
+### onBackground
+
+- <code class="function-signature">**onBackground**(input, background): string</code>
+
+Computes how the first color would look on top of the second color.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `background` | `string` |
+
+### setAlpha
+
+- <code class="function-signature">**setAlpha**(input, newAlpha): string</code>
+
+Overrides the alpha value of a color with the given value. Values should be between 0 and 1.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `newAlpha` | `number` |
+
+### setLuminance
+
+- <code class="function-signature">**setLuminance**(input, targetLuminance): string</code>
+
+Mixes a color with white or black to achieve the desired luminance. Luminance values should be between 0 and 1.
+
+#### Arguments
+
+| Parameter | Type |
+| :------ | :------ |
+| `input` | `string` |
+| `targetLuminance` | `number` |
+
 ## Referenced types
 
 ### AnnotationBaseOptions

--- a/docs/src/content/docs/reference/core-api.mdx
+++ b/docs/src/content/docs/reference/core-api.mdx
@@ -919,17 +919,20 @@ See [`InlineStyleAnnotationOptions`](#inlinestyleannotationoptions) for the enti
 
 ### createInlineSvgUrl
 
-- <code class="function-signature">**createInlineSvgUrl**(svgContents): string</code>
+- <code class="function-signature">**createInlineSvgUrl**(svgContents, options): string</code>
 
 Creates an inline SVG image data URL from the given contents of an SVG file.
 
 You can use it to embed SVG images directly into your plugin's styles or HAST.
+
+The optional `options` argument allows further customization of the generated URL.
 
 #### Arguments
 
 | Parameter | Type |
 | :------ | :------ |
 | `svgContents` | `string` \| `string`[] |
+| `options` | [`CreateInlineSvgUrlOptions`](/reference/core-api/#createinlinesvgurloptions) |
 
 ## Color analysis functions
 
@@ -1227,6 +1230,27 @@ The target hue in degrees (0 – 360).
 The lightness (0 – 1) that the target chroma was measured at.
 
 If given, the chroma will be adjusted relative to this lightness before applying it to the input color.
+</dd>
+</dl>
+
+### CreateInlineSvgUrlOptions
+
+<PropertySignature>
+- Type: `Object`
+</PropertySignature>
+
+#### Object properties
+
+<dl class="type-declaration-list">
+<dt>keepSize</dt>
+<dd>
+<PropertySignature>
+- Type: `boolean`
+</PropertySignature>
+Whether to keep the original size of the SVG image.
+
+By default, any `width` and `height` attributes inside the SVG tag are removed.
+
 </dd>
 </dl>
 

--- a/docs/src/content/docs/reference/core-api.mdx
+++ b/docs/src/content/docs/reference/core-api.mdx
@@ -923,7 +923,7 @@ See [`InlineStyleAnnotationOptions`](#inlinestyleannotationoptions) for the enti
 
 Creates an inline SVG image data URL from the given contents of an SVG file.
 
-You can use it to embed SVG images directly into your plugin's styles or HAST.
+You can use it to embed SVG images directly into a plugin's styles or HAST, or pass it to an existing `styleOverrides` icon setting.
 
 The optional `options` argument allows further customization of the generated URL.
 

--- a/packages/@expressive-code/core/src/helpers/assets.ts
+++ b/packages/@expressive-code/core/src/helpers/assets.ts
@@ -1,9 +1,29 @@
+export type CreateInlineSvgUrlOptions = {
+	/**
+	 * Whether to keep the original size of the SVG image.
+	 *
+	 * By default, any `width` and `height` attributes inside the SVG tag are removed.
+	 *
+	 * @default false
+	 */
+	keepSize?: boolean | undefined
+}
+
 /**
  * Creates an inline SVG image data URL from the given contents of an SVG file.
  *
  * You can use it to embed SVG images directly into your plugin's styles or HAST.
+ *
+ * The optional `options` argument allows further customization of the generated URL.
  */
-export function createInlineSvgUrl(svgContents: string | string[]) {
-	const svgString = Array.isArray(svgContents) ? svgContents.join('') : svgContents
+export function createInlineSvgUrl(svgContents: string | string[], options: CreateInlineSvgUrlOptions = {}): string {
+	const { keepSize = false } = options
+	let svgString = Array.isArray(svgContents) ? svgContents.join('') : svgContents
+	// Process attributes inside the svg tag
+	svgString = svgString.replace(/^\s*(<svg)\s+([^>]+)\s*(\/?>)/, (match, tagStart, attrs, tagEnd) => {
+		if (typeof attrs !== 'string') return match
+		if (!keepSize) attrs = attrs.replaceAll(/(?:width|height)\s*=\s*(?:(["'])[\w\s]*\1|\d+)\s*/g, '')
+		return `${tagStart} ${attrs}${tagEnd}`
+	})
 	return `url("data:image/svg+xml,${encodeURIComponent(svgString)}")`
 }

--- a/packages/@expressive-code/core/src/helpers/assets.ts
+++ b/packages/@expressive-code/core/src/helpers/assets.ts
@@ -12,7 +12,8 @@ export type CreateInlineSvgUrlOptions = {
 /**
  * Creates an inline SVG image data URL from the given contents of an SVG file.
  *
- * You can use it to embed SVG images directly into your plugin's styles or HAST.
+ * You can use it to embed SVG images directly into a plugin's styles or HAST,
+ * or pass it to an existing `styleOverrides` icon setting.
  *
  * The optional `options` argument allows further customization of the generated URL.
  */

--- a/packages/@expressive-code/core/src/helpers/assets.ts
+++ b/packages/@expressive-code/core/src/helpers/assets.ts
@@ -1,0 +1,9 @@
+/**
+ * Creates an inline SVG image data URL from the given contents of an SVG file.
+ *
+ * You can use it to embed SVG images directly into your plugin's styles or HAST.
+ */
+export function createInlineSvgUrl(svgContents: string | string[]) {
+	const svgString = Array.isArray(svgContents) ? svgContents.join('') : svgContents
+	return `url("data:image/svg+xml,${encodeURIComponent(svgString)}")`
+}

--- a/packages/@expressive-code/core/src/index.ts
+++ b/packages/@expressive-code/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './common/style-settings'
 export * from './common/style-variants'
 export * from './common/theme'
 
+export * from './helpers/assets'
 export * from './helpers/ast'
 export * from './helpers/color-transforms'
 export * from './helpers/i18n'

--- a/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
+++ b/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
@@ -1,4 +1,4 @@
-import { PluginStyleSettings, ResolverContext, codeLineClass, setAlpha } from '@expressive-code/core'
+import { PluginStyleSettings, ResolverContext, codeLineClass, createInlineSvgUrl, setAlpha } from '@expressive-code/core'
 
 export const collapsibleSectionClass = 'ec-section'
 
@@ -85,6 +85,20 @@ export interface CollapsibleSectionsStyleSettings {
 	 * ({ theme }) => setAlpha(theme.colors['editor.foldBackground'], 0.1) || 'rgb(84 174 255 / 10%)'
 	 */
 	openBackgroundColorCollapsible: string
+	/**
+	 * An inline SVG URL for the expand icon.
+	 *
+	 * Expects a string in the format `url("data:image/svg+xml,...")`, which can
+	 * be generated from the contents of an SVG file using {@link createInlineSvgUrl}.
+	 */
+	expandIcon: string
+	/**
+	 * An inline SVG URL for the collapse icon.
+	 *
+	 * Expects a string in the format `url("data:image/svg+xml,...")`, which can
+	 * be generated from the contents of an SVG file using {@link createInlineSvgUrl}.
+	 */
+	collapseIcon: string
 }
 
 export const collapsibleSectionsStyleSettings = new PluginStyleSettings({
@@ -105,6 +119,18 @@ export const collapsibleSectionsStyleSettings = new PluginStyleSettings({
 			openBackgroundColor: 'transparent',
 			openBackgroundColorCollapsible: ({ theme }) => setAlpha(theme.colors['editor.foldBackground'], 0.1) || 'rgb(84 174 255 / 10%)',
 			openBorderColor: 'transparent',
+			// Icon source: Octicons (MIT licensed)
+			expandIcon: createInlineSvgUrl([
+				`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>`,
+				`<path d='m8.177.677 2.896 2.896a.25.25 0 0 1-.177.427H8.75v1.25a.75.75 0 0 1-1.5 0V4H5.104a.25.25 0 0 1-.177-.427L7.823.677a.25.25 0 0 1 .354 0ZM7.25 10.75a.75.75 0 0 1 1.5 0V12h2.146a.25.25 0 0 1 .177.427l-2.896 2.896a.25.25 0 0 1-.354 0l-2.896-2.896A.25.25 0 0 1 5.104 12H7.25v-1.25Zm-5-2a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM6 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 6 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM12 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 12 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5Z'/>`,
+				`</svg>`,
+			]),
+			// Icon source: Octicons (MIT licensed)
+			collapseIcon: createInlineSvgUrl([
+				`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'>`,
+				`<path d='M10.896 2H8.75V.75a.75.75 0 0 0-1.5 0V2H5.104a.25.25 0 0 0-.177.427l2.896 2.896a.25.25 0 0 0 .354 0l2.896-2.896A.25.25 0 0 0 10.896 2ZM8.75 15.25a.75.75 0 0 1-1.5 0V14H5.104a.25.25 0 0 1-.177-.427l2.896-2.896a.25.25 0 0 1 .354 0l2.896 2.896a.25.25 0 0 1-.177.427H8.75v1.25Zm-6.5-6.5a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM6 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 6 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM12 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 12 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5Z'/>`,
+				`</svg>`,
+			]),
 		},
 	},
 	cssVarReplacements: [['collapsibleSections', 'cs']],
@@ -112,13 +138,6 @@ export const collapsibleSectionsStyleSettings = new PluginStyleSettings({
 })
 
 export function getCollapsibleSectionsBaseStyles({ cssVar }: ResolverContext) {
-	// Icon source: Octicons (MIT licensed)
-	const unfoldSvg = createInlineSvgUrl(
-		'm8.177.677 2.896 2.896a.25.25 0 0 1-.177.427H8.75v1.25a.75.75 0 0 1-1.5 0V4H5.104a.25.25 0 0 1-.177-.427L7.823.677a.25.25 0 0 1 .354 0ZM7.25 10.75a.75.75 0 0 1 1.5 0V12h2.146a.25.25 0 0 1 .177.427l-2.896 2.896a.25.25 0 0 1-.354 0l-2.896-2.896A.25.25 0 0 1 5.104 12H7.25v-1.25Zm-5-2a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM6 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 6 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM12 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 12 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5Z'
-	)
-	const foldSvg = createInlineSvgUrl(
-		'M10.896 2H8.75V.75a.75.75 0 0 0-1.5 0V2H5.104a.25.25 0 0 0-.177.427l2.896 2.896a.25.25 0 0 0 .354 0l2.896-2.896A.25.25 0 0 0 10.896 2ZM8.75 15.25a.75.75 0 0 1-1.5 0V14H5.104a.25.25 0 0 1-.177-.427l2.896-2.896a.25.25 0 0 1 .354 0l2.896 2.896a.25.25 0 0 1-.177.427H8.75v1.25Zm-6.5-6.5a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM6 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 6 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5ZM12 8a.75.75 0 0 1-.75.75h-.5a.75.75 0 0 1 0-1.5h.5A.75.75 0 0 1 12 8Zm2.25.75a.75.75 0 0 0 0-1.5h-.5a.75.75 0 0 0 0 1.5h.5Z'
-	)
 	return `
 		.${collapsibleSectionClass} {
 			position: relative;
@@ -175,8 +194,8 @@ export function getCollapsibleSectionsBaseStyles({ cssVar }: ResolverContext) {
 					}
 				}
 				.expand::after {
-					-webkit-mask-image: ${unfoldSvg};
-					mask-image: ${unfoldSvg};
+					-webkit-mask-image: ${cssVar('collapsibleSections.expandIcon')};
+					mask-image: ${cssVar('collapsibleSections.expandIcon')};
 					/* Ensure that the expand icons of closed sections get printed to avoid gap */
 					-webkit-print-color-adjust: exact;
 					print-color-adjust: exact;
@@ -184,8 +203,8 @@ export function getCollapsibleSectionsBaseStyles({ cssVar }: ResolverContext) {
 				.collapse {
 					display: none;
 					&::after {
-						-webkit-mask-image: ${foldSvg};
-						mask-image: ${foldSvg};
+						-webkit-mask-image: ${cssVar('collapsibleSections.collapseIcon')};
+						mask-image: ${cssVar('collapsibleSections.collapseIcon')};
 					}
 				}
 				.text {
@@ -241,10 +260,4 @@ export function getCollapsibleSectionsBaseStyles({ cssVar }: ResolverContext) {
 			}
 		}
 	`
-}
-
-function createInlineSvgUrl(d: string) {
-	const svg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path d='${d}'/></svg>`
-	const encodedSvg = svg.replace(/</g, '%3C').replace(/>/g, '%3E')
-	return `url("data:image/svg+xml,${encodedSvg}")`
 }

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -1,5 +1,5 @@
 import type { ResolverContext } from '@expressive-code/core'
-import { PluginStyleSettings, codeLineClass, multiplyAlpha, onBackground, setLuminance } from '@expressive-code/core'
+import { PluginStyleSettings, codeLineClass, createInlineSvgUrl, multiplyAlpha, onBackground, setLuminance } from '@expressive-code/core'
 import type { PluginFramesOptions } from '.'
 
 export interface FramesStyleSettings {
@@ -189,6 +189,22 @@ export interface FramesStyleSettings {
 	 * @default 'white'
 	 */
 	tooltipSuccessForeground: string
+	/**
+	 * An inline SVG URL for the copy to clipboard icon.
+	 *
+	 * Expects a string in the format `url("data:image/svg+xml,...")`, which can
+	 * be generated from the contents of an SVG file using {@link createInlineSvgUrl}.
+	 */
+	copyIcon: string
+	/**
+	 * An inline SVG URL for the terminal icon.
+	 *
+	 * Expects a string in the format `url("data:image/svg+xml,...")`, which can
+	 * be generated from the contents of an SVG file using {@link createInlineSvgUrl}.
+	 *
+	 * Defaults to three dots in a row.
+	 */
+	terminalIcon: string
 }
 
 declare module '@expressive-code/core' {
@@ -231,31 +247,25 @@ export const framesStyleSettings = new PluginStyleSettings({
 			inlineButtonBorderOpacity: '0.4',
 			tooltipSuccessBackground: ({ theme }) => setLuminance(theme.colors['terminal.ansiGreen'] || '#0dbc79', 0.18),
 			tooltipSuccessForeground: 'white',
+			copyIcon: createInlineSvgUrl([
+				`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.75'>`,
+				`<path d='M3 19a2 2 0 0 1-1-2V2a2 2 0 0 1 1-1h13a2 2 0 0 1 2 1'/>`,
+				`<rect x='6' y='5' width='16' height='18' rx='1.5' ry='1.5'/>`,
+				`</svg>`,
+			]),
+			terminalIcon: createInlineSvgUrl([
+				`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 16' preserveAspectRatio='xMidYMid meet'>`,
+				`<circle cx='8' cy='8' r='8'/>`,
+				`<circle cx='30' cy='8' r='8'/>`,
+				`<circle cx='52' cy='8' r='8'/>`,
+				`</svg>`,
+			]),
 		},
 	},
 	preventUnitlessValues: ['frames.editorActiveTabIndicatorHeight', 'frames.editorTabBorderRadius'],
 })
 
 export function getFramesBaseStyles({ cssVar }: ResolverContext, options: PluginFramesOptions) {
-	const dotsSvg = [
-		`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 60 16' preserveAspectRatio='xMidYMid meet'>`,
-		`<circle cx='8' cy='8' r='8'/>`,
-		`<circle cx='30' cy='8' r='8'/>`,
-		`<circle cx='52' cy='8' r='8'/>`,
-		`</svg>`,
-	].join('')
-	const escapedDotsSvg = dotsSvg.replace(/</g, '%3C').replace(/>/g, '%3E')
-	const terminalTitlebarDots = `url("data:image/svg+xml,${escapedDotsSvg}")`
-
-	const copySvg = [
-		`<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='1.75'>`,
-		`<path d='M3 19a2 2 0 0 1-1-2V2a2 2 0 0 1 1-1h13a2 2 0 0 1 2 1'/>`,
-		`<rect x='6' y='5' width='16' height='18' rx='1.5' ry='1.5'/>`,
-		`</svg>`,
-	].join('')
-	const escapedCopySvg = copySvg.replace(/</g, '%3C').replace(/>/g, '%3E')
-	const copyToClipboard = `url("data:image/svg+xml,${escapedCopySvg}")`
-
 	const tabBarBackground = [
 		`linear-gradient(to top, ${cssVar('frames.editorTabBarBorderBottomColor')} ${cssVar('borderWidth')}, transparent ${cssVar('borderWidth')})`,
 		`linear-gradient(${cssVar('frames.editorTabBarBackground')}, ${cssVar('frames.editorTabBarBackground')})`,
@@ -376,9 +386,9 @@ export function getFramesBaseStyles({ cssVar }: ResolverContext, options: Plugin
 					line-height: 0;
 					background-color: ${cssVar('frames.terminalTitlebarDotsForeground')};
 					opacity: ${cssVar('frames.terminalTitlebarDotsOpacity')};
-					-webkit-mask-image: ${terminalTitlebarDots};
+					-webkit-mask-image: ${cssVar('frames.terminalIcon')};
 					-webkit-mask-repeat: no-repeat;
-					mask-image: ${terminalTitlebarDots};
+					mask-image: ${cssVar('frames.terminalIcon')};
 					mask-repeat: no-repeat;
 				}
 				/* Display a border below the header */
@@ -465,9 +475,9 @@ export function getFramesBaseStyles({ cssVar }: ResolverContext, options: Plugin
 				pointer-events: none;
 				inset: 0;
 				background-color: ${cssVar('frames.inlineButtonForeground')};
-				-webkit-mask-image: ${copyToClipboard};
+				-webkit-mask-image: ${cssVar('frames.copyIcon')};
 				-webkit-mask-repeat: no-repeat;
-				mask-image: ${copyToClipboard};
+				mask-image: ${cssVar('frames.copyIcon')};
 				mask-repeat: no-repeat;
 				margin: 0.475rem;
 				line-height: 0;

--- a/packages/@expressive-code/plugin-shiki/src/index.ts
+++ b/packages/@expressive-code/plugin-shiki/src/index.ts
@@ -57,7 +57,7 @@ export interface PluginShikiOptions {
 	 *
 	 * https://expressive-code.com/key-features/syntax-highlighting/#transformers
 	 */
-	transformers?: ShikiTransformer[] | undefined
+	transformers?: ShikiTransformer[] | unknown[] | undefined
 	/**
 	 * The RegExp engine to use for syntax highlighting.
 	 *


### PR DESCRIPTION
Fixes #300 by adding a new utility function for inlining SVGs and updating the frames & collapsible sections plugins to support custom SVG icons:

- Adds the exported function `createInlineSvgUrl`, which creates an inline SVG image data URL from an SVG string (the contents of an SVG file). It can be used to embed SVG images directly into plugin styles or HAST, or pass them to a `styleOverrides` icon setting.

- Adds the following new `styleOverrides` settings:
  - `frames.copyIcon`: Allows overriding the SVG icon used for the copy button.
  - `frames.terminalIcon`: Allows overriding the SVG icon used for the terminal window frame. Defaults to three dots in the top left corner.
  - `collapsibleSections.expandIcon` and `collapsibleSections.collapseIcon`: Allows overriding the SVG icons used for the expand/collapse buttons.

- Also fixes a Shiki transformer type incompatibility issue I discovered while updating the docs for the new features.