### PR TITLE
feat: add support for controlling bundle size

### DIFF
--- a/packages/@expressive-code/plugin-shiki/src/transformers.ts
+++ b/packages/@expressive-code/plugin-shiki/src/transformers.ts
@@ -1,9 +1,11 @@
 import { ExpressiveCodeBlock } from '@expressive-code/core'
-import type { PluginShikiOptions } from '.'
+import type { PluginShikiCoreOptions } from '.'
 import type { CodeToHastOptions, ShikiTransformer, ShikiTransformerContextSource, ThemedToken } from 'shiki'
 
+type TransformerOptions = Pick<PluginShikiCoreOptions<never>, 'transformers'>
+
 export type BaseHookArgs = {
-	options: PluginShikiOptions
+	options: TransformerOptions
 	code: string
 	codeBlock: ExpressiveCodeBlock
 	codeToTokensOptions: CodeToHastOptions
@@ -12,7 +14,7 @@ export type BaseHookArgs = {
 /**
  * Throws an error if any of the configured transformers use unsupported hooks.
  */
-export function validateTransformers(options: PluginShikiOptions) {
+export function validateTransformers(options: TransformerOptions) {
 	if (!options.transformers) return
 	const unsupportedTransformerHooks: (keyof ShikiTransformer)[] = ['code', 'line', 'postprocess', 'pre', 'root', 'span']
 	for (const transformer of coerceTransformers(options.transformers)) {

--- a/packages/expressive-code/src/index.ts
+++ b/packages/expressive-code/src/index.ts
@@ -10,7 +10,9 @@ export * from '@expressive-code/plugin-frames'
 export * from '@expressive-code/plugin-shiki'
 export * from '@expressive-code/plugin-text-markers'
 
-export interface ExpressiveCodeConfig extends ExpressiveCodeEngineConfig {
+export interface ExpressiveCodeCoreConfig extends ExpressiveCodeEngineConfig {}
+
+export interface ExpressiveCodeConfig extends ExpressiveCodeCoreConfig {
 	/**
 	 * The Shiki plugin adds syntax highlighting to code blocks.
 	 *
@@ -35,7 +37,9 @@ export interface ExpressiveCodeConfig extends ExpressiveCodeEngineConfig {
 	frames?: PluginFramesOptions | boolean | undefined
 }
 
-export class ExpressiveCode extends ExpressiveCodeEngine {
+export class ExpressiveCodeCore extends ExpressiveCodeEngine {}
+
+export class ExpressiveCode extends ExpressiveCodeCore {
 	constructor({ shiki, textMarkers, frames, ...baseConfig }: ExpressiveCodeConfig = {}) {
 		// Collect all default plugins with their configuration,
 		// but skip those that were disabled or already added to plugins

--- a/packages/rehype-expressive-code/package.json
+++ b/packages/rehype-expressive-code/package.json
@@ -53,14 +53,18 @@
   },
   "devDependencies": {
     "@internal/test-utils": "workspace:^",
+    "@shikijs/langs-precompiled": "^3.3.0",
     "@types/mdast": "^3.0.11",
     "@types/unist": "^2.0.6",
     "mdast-util-mdx-jsx": "^3.1.2",
     "rehype-stringify": "^9.0.3",
     "remark-parse": "^10.0.1",
     "remark-rehype": "^10.1.0",
+    "rollup-plugin-bundle-stats": "^4.19.1",
+    "rollup-plugin-visualizer": "^5.14.0",
     "shiki": "^3.2.2",
     "unified": "^10.1.2",
-    "vfile": "^6.0.1"
+    "vfile": "^6.0.1",
+    "vite": "^6.0.7"
   }
 }

--- a/packages/rehype-expressive-code/test/__snapshots__/bundle-size.test.ts.snap
+++ b/packages/rehype-expressive-code/test/__snapshots__/bundle-size.test.ts.snap
@@ -1,0 +1,348 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-bundle - engine-all.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+    "javascript:engine-raw",
+    "oniguruma",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [
+    "typescript",
+  ],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-bundle - engine-javascript-compile.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-bundle - engine-javascript-raw.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-raw",
+  ],
+  "langs": [],
+  "langs-precompiled": [
+    "javascript",
+  ],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-bundle - engine-oniguruma.ts 1`] = `
+{
+  "engine": [
+    "oniguruma",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-bundle - no-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-bundle - with-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-bundle - with-themes-dynamic.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core - no-themes.ts 1`] = `
+{
+  "engine": [],
+  "langs": [],
+  "langs-precompiled": [],
+  "themes": [],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core - with-themes.ts 1`] = `
+{
+  "engine": [],
+  "langs": [],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core - with-themes-dynamic.ts 1`] = `
+{
+  "engine": [],
+  "langs": [],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-bundle - engine-all.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+    "javascript:engine-raw",
+    "oniguruma",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [
+    "typescript",
+  ],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-bundle - engine-javascript-compile.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-bundle - engine-javascript-raw.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-raw",
+  ],
+  "langs": [],
+  "langs-precompiled": [
+    "javascript",
+  ],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-bundle - engine-oniguruma.ts 1`] = `
+{
+  "engine": [
+    "oniguruma",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-bundle - no-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-bundle - with-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-bundle - with-themes-dynamic.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-highlighter - no-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-highlighter - with-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-core-highlighter - with-themes-dynamic.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-highlighter - no-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-highlighter - with-themes.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;
+
+exports[`integration with shiki affect on ec bundle size > rehype-ec-highlighter - with-themes-dynamic.ts 1`] = `
+{
+  "engine": [
+    "javascript:engine-compile",
+  ],
+  "langs": [
+    "javascript",
+  ],
+  "langs-precompiled": [],
+  "themes": [
+    "dracula",
+    "light-plus",
+  ],
+}
+`;

--- a/packages/rehype-expressive-code/test/bundle-size.test.ts
+++ b/packages/rehype-expressive-code/test/bundle-size.test.ts
@@ -1,0 +1,275 @@
+import { describe, ExpectStatic, test } from 'vitest'
+import { basename, extname, join } from 'node:path'
+import { build, Rollup } from 'vite'
+import { visualizer } from 'rollup-plugin-visualizer'
+import { bundledThemes, bundledLanguagesInfo } from 'shiki'
+import { bundleStats } from 'rollup-plugin-bundle-stats'
+
+type ShikiDetails = Awaited<ReturnType<typeof buildFixture>>
+
+describe('integration with shiki affect on ec bundle size', () => {
+	/* EC Core Tests */
+	test.for(['no-themes.ts', 'with-themes.ts', 'with-themes-dynamic.ts'])('rehype-ec-core - %s', async (fileName, { expect }) => {
+		const details = await buildFixture({
+			fixtureDir: 'bundle-size/rehype-ec-core',
+			entryPoint: fileName,
+			outputDir: 'dist',
+		})
+		assertSnapshot(expect, details, false, 500000)
+	})
+
+	/* EC Tests */
+	test.for(['no-themes.ts', 'with-themes.ts', 'with-themes-dynamic.ts', 'shiki-false.ts'])('rehype-ec - %s', async (fileName, { expect }) => {
+		const details = await buildFixture({
+			fixtureDir: 'bundle-size/rehype-ec',
+			entryPoint: fileName,
+			outputDir: 'dist',
+		})
+		const baseLangs = bundledLanguagesInfo.map((i) => i.id)
+		const themes = Object.keys(bundledThemes)
+
+		// We don't snapshot here because Shiki can evolve their full bundle
+		// and we do not want test to break every time they change it. Instead,
+		// we make sure we match what is in their current bundle. Since we are
+		// identifying what's in our bundle using filenames, it won't include language
+		// aliases so we only compare against the base languages. Additionally, due to bundling
+		// and shared files across languages, we will have more files than languages
+		// but we should have a file for every language.
+		expect(details.modules.shiki.files.bundle.langs.length).toBeGreaterThan(baseLangs.length)
+		expect(details.modules.shiki.files.bundle['langs-precompiled'].length).toBe(0)
+		expect(details.modules.shiki.files.bundle.themes.length).toBe(themes.length)
+		expect(details.modules.shiki.files.bundle.engine.length).toBe(2)
+		expect(details.totalSize).toBeGreaterThan(0)
+		expect(details.totalSize).toBeLessThan(10000000)
+	})
+
+	/* EC Bundle Tests */
+	test.for([
+		['no-themes.ts'],
+		['with-themes.ts'],
+		['with-themes-dynamic.ts'],
+		['engine-javascript-compile.ts'],
+		['engine-javascript-raw.ts'],
+		['engine-oniguruma.ts'],
+		['engine-all.ts', 1100000],
+	] as [string, number | undefined][])('rehype-ec-core-bundle - %s', async ([fileName, size], { expect }) => {
+		const details = await buildFixture({
+			fixtureDir: 'bundle-size/rehype-ec-core-bundle',
+			entryPoint: fileName,
+			outputDir: 'dist',
+		})
+		assertSnapshot(expect, details, true, size || 900000)
+	})
+
+	// /* EC Highlighter Tests */
+	test.for(['no-themes.ts', 'with-themes.ts', 'with-themes-dynamic.ts'])('rehype-ec-core-highlighter - %s', async (fileName, { expect }) => {
+		const details = await buildFixture({
+			fixtureDir: 'bundle-size/rehype-ec-core-highlighter',
+			entryPoint: fileName,
+			outputDir: 'dist',
+		})
+		assertSnapshot(expect, details, true, 900000)
+	})
+})
+
+async function buildFixture({
+	fixtureDir,
+	outputDir = 'dist',
+	entryPoint = 'index.ts',
+	keepPreviousBuild = false,
+}: {
+	fixtureDir: string
+	entryPoint: string
+	outputDir?: string | undefined
+	keepPreviousBuild?: boolean | undefined
+}) {
+	const fixturePath = join(__dirname, 'fixtures', fixtureDir)
+	const moduleName = basename(entryPoint, extname(entryPoint))
+	const outputDirPath = join(fixturePath, outputDir, moduleName)
+	const reportDir = '.vite'
+	const manifestFilePath = join(reportDir, 'manifest.json')
+	const visualizerStatsFilePath = join(outputDirPath, reportDir, 'visualizer-stats.json')
+
+	const buildResult = await build({
+		root: fixturePath,
+		plugins: [
+			// Generate module graph via https://github.com/btd/rollup-plugin-visualizer
+			//   - View JSON in <fixturePath>/dist/<moduleName>/.vite/visualizer-status.json
+			//   - View HTML w/ rollup-plugin-visualizer CLI from within rehype-expressive-code directory (see https://github.com/btd/rollup-plugin-visualizer?tab=readme-ov-file#cli)
+			//       npx rollup-plugin-visualizer <fixturePath>/dist/<moduleName>/.vite/visualizer-stats.json --template <template> --open
+			//         NOTE: Within the web UI, you can apply an "Include" filter of "*/**/*shiki*/**/*" to see just the shiki modules
+			//         eg., npx rollup-plugin-visualizer ./test/fixtures/bundle-size/rehype-ec-bundle/dist/with-themes/.vite/visualizer-stats.json --template treemap --open
+			visualizer({
+				filename: visualizerStatsFilePath,
+				template: 'raw-data',
+			}),
+			// Generate stats summary via https://github.com/relative-ci/bundle-stats/tree/master/packages/rollup-plugin
+			//   - View JSON in <fixturePath>/dist/<moduleName>/.vite/bundle-stats.json
+			//   - View HTML in <fixturePath>/dist/<moduleName>/.vite/bundle-stats.html
+			bundleStats({
+				compare: false,
+				json: true,
+				html: true,
+				outDir: reportDir,
+			}),
+		],
+		build: {
+			emptyOutDir: !keepPreviousBuild,
+			target: ['esnext'],
+			outDir: outputDirPath,
+			manifest: manifestFilePath,
+			lib: {
+				entry: join(fixturePath, entryPoint),
+				name: moduleName,
+				fileName: moduleName,
+				formats: ['es'],
+			},
+			rollupOptions: {
+				output: {
+					// generate a single chunk to simplify output from vite
+					inlineDynamicImports: true,
+					// required for rollup-plugin-bundle-stats See https://relative-ci.com/documentation/guides/vite-config
+					assetFileNames: '[name].[hash][extname]',
+					chunkFileNames: '[name].[hash].js', // rollup default is [name].js
+					entryFileNames: '[name].[hash].js',
+				},
+			},
+		},
+	})
+
+	const rollupOutputs = Array.isArray(buildResult) ? buildResult : ([buildResult] as Rollup.RollupOutput[])
+	return collectModules(fixturePath, rollupOutputs)
+}
+
+function collectModules(fixturePath: string, rollupOutputs: Rollup.RollupOutput[]) {
+	const modulesFromBuildResult = {
+		modules: {
+			shiki: {
+				files: {
+					bundle: {
+						themes: new Set<string>(),
+						langs: new Set<string>(),
+						'langs-precompiled': new Set<string>(),
+						engine: new Set<string>(),
+					},
+					other: new Set<string>(),
+				},
+				totalSize: 0,
+			},
+			ecPlugins: {
+				'plugin-shiki': {
+					files: new Set<string>(),
+					totalSize: 0,
+				},
+				'plugin-frames': {
+					files: new Set<string>(),
+					totalSize: 0,
+				},
+				'plugin-text-markers': {
+					files: new Set<string>(),
+					totalSize: 0,
+				},
+			},
+		},
+		totalSize: 0,
+	}
+
+	for (const rollupOutput of rollupOutputs) {
+		for (const output of rollupOutput.output) {
+			if (output.type !== 'chunk') continue
+
+			modulesFromBuildResult.totalSize += getByteSize(output.code)
+
+			const isShikiModule = (id: string) => (id.includes('/shiki/') || id.includes('/@shikijs/')) && !id.includes(fixturePath)
+
+			const extractShikiPath = (input: string) => {
+				const match = input.match(/.*(?:\/@shikijs\/|\/shiki\/)/)
+				if (!match || !match[0]) {
+					throw new Error('No match found after /shiki/ or /@shikijs/')
+				}
+				return input.slice(match[0].length)
+			}
+
+			const processShikiModule = (id: string, module: Rollup.RenderedModule) => {
+				// shiki uses unbuild which puts shared chunks in /shared/ folder so separate them so we don't treat those
+				// chunks as langs/themes/engines. See https://github.com/unjs/unbuild/blob/a6570a57a58b223ba278e8129b07f46ff27e9293/src/builders/rollup/utils.ts#L52
+				const match = id.match(/\/(langs|themes|langs-precompiled)\/|\/(engine)-(javascript|oniguruma)\/(?!.*\/shared\/)/i)
+				const shikiPath = extractShikiPath(id)
+				const category = (match?.[1] || match?.[2]) as keyof typeof modulesFromBuildResult.modules.shiki.files.bundle | undefined
+				const engine = match?.[3]
+				const value = category ? (engine === 'javascript' ? 'javascript:' + basename(shikiPath, extname(shikiPath)) : engine ?? basename(shikiPath, extname(shikiPath))) : shikiPath
+
+				if (category) {
+					modulesFromBuildResult.modules.shiki.files.bundle[category].add(value)
+				} else {
+					modulesFromBuildResult.modules.shiki.files.other.add(value)
+				}
+				modulesFromBuildResult.modules.shiki.totalSize += module.renderedLength
+			}
+
+			for (const [id, module] of Object.entries(output.modules)) {
+				if (isShikiModule(id)) {
+					processShikiModule(id, module)
+					continue
+				}
+
+				const match = id.match(/\/(plugin-(?:shiki|frames|text-markers))\/(.*)/i)
+				if (match) {
+					const pluginName = match?.[1] as keyof typeof modulesFromBuildResult.modules.ecPlugins | undefined
+					if (!pluginName) {
+						throw new Error('No known plugin match found')
+					}
+					modulesFromBuildResult.modules.ecPlugins[pluginName].files.add(match[0])
+					modulesFromBuildResult.modules.ecPlugins[pluginName].totalSize += module.renderedLength
+				}
+			}
+		}
+	}
+
+	return sortNames(modulesFromBuildResult)
+}
+
+type Normalize<T> = T extends Set<infer U> ? Normalize<U>[] : T extends Array<infer U> ? Normalize<U>[] : T extends object ? { [K in keyof T]: Normalize<T[K]> } : T
+
+function sortNames<T>(obj: T): Normalize<T> {
+	if (obj instanceof Set || Array.isArray(obj)) {
+		return Array.from(obj).map(sortNames).sort() as Normalize<T>
+	} else if (obj !== null && typeof obj === 'object') {
+		const result = {} as { [K in keyof T]: Normalize<T[K]> }
+		for (const key in obj) {
+			if (Object.prototype.hasOwnProperty.call(obj, key)) {
+				result[key] = sortNames(obj[key])
+			}
+		}
+		return result as Normalize<T>
+	}
+	return obj as Normalize<T>
+}
+
+export function getByteSize(content: string): number {
+	return !content ? 0 : Buffer.from(content).length
+}
+
+function assertSnapshot(expect: ExpectStatic, details: ShikiDetails, expectOther: boolean, expectSize: number) {
+	expect(details.modules.shiki.files.bundle).toMatchSnapshot()
+	expect(details.totalSize).toBeGreaterThan(0)
+	expect(details.totalSize).toBeLessThan(expectSize)
+	expect(Object.keys(details.modules.ecPlugins).length).toBe(3)
+	expect(details.modules.ecPlugins['plugin-shiki'].files.length).toBe(expectOther ? 1 : 0)
+	expect(details.modules.ecPlugins['plugin-shiki'].totalSize).toBeLessThanOrEqual(expectOther ? 30000 : 0)
+	// TODO: frames & text-markers will still contain some styling related code (css), etc. so while down to ~6k from ~45k they do not
+	// get to zero currently.  Need to further investigate and refactor/modify as needed to fully eliminate
+	expect(details.modules.ecPlugins['plugin-frames'].files.length).toBe(1)
+	expect(details.modules.ecPlugins['plugin-frames'].totalSize).toBeLessThan(4500)
+	expect(details.modules.ecPlugins['plugin-text-markers'].files.length).toBe(1)
+	expect(details.modules.ecPlugins['plugin-text-markers'].totalSize).toBeLessThan(3500)
+	// We do not snapshot other to avoid potential test failing as new versions of shiki
+	// are released. We are mainly concerned with the langs/themes/engines so we snapshot
+	// those and then ensure other doesn't become unreasonable.
+	if (expectOther) {
+		expect(details.modules.shiki.files.other.length).toBeGreaterThan(0)
+		expect(details.modules.shiki.files.other.length).toBeLessThan(15)
+	} else {
+		expect(details.modules.shiki.files.other.length).toBe(0)
+	}
+}

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-all.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-all.ts
@@ -1,0 +1,39 @@
+import { loadShikiThemeFromBundle, rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions, pluginShikiBundle, PluginShikiBundleOptions } from 'rehype-expressive-code'
+import { createJavaScriptRegexEngine, createOnigurumaEngine } from 'shiki'
+import { createJavaScriptRawEngine } from 'shiki/engine/javascript'
+
+type BundledLanguage = 'javascript' | 'typescript'
+type BundledTheme = 'light-plus'
+
+const shikiOptions: PluginShikiBundleOptions<BundledLanguage, BundledTheme> = {
+	engine: async () => {
+		// need something conditional to avoid treeshaking
+		switch (new Date().getDay()) {
+			case 0:
+				return createJavaScriptRegexEngine()
+			case 1:
+				return createJavaScriptRawEngine()
+			default:
+				return createOnigurumaEngine()
+		}
+	},
+	bundledLangs: {
+		javascript: () => import('shiki/langs/javascript.mjs'),
+		typescript: () => import('@shikijs/langs-precompiled/typescript'),
+	},
+	bundledThemes: {
+		'light-plus': () => import('shiki/themes/light-plus.mjs'),
+	},
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [],
+	plugins: [pluginShikiBundle<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromBundle(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-javascript-compile.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-javascript-compile.ts
@@ -1,0 +1,27 @@
+import { loadShikiThemeFromBundle, rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions, pluginShikiBundle, PluginShikiBundleOptions } from 'rehype-expressive-code'
+import { createJavaScriptRegexEngine } from 'shiki'
+
+type BundledLanguage = 'javascript'
+type BundledTheme = 'light-plus'
+
+const shikiOptions: PluginShikiBundleOptions<BundledLanguage, BundledTheme> = {
+	engine: createJavaScriptRegexEngine,
+	bundledLangs: {
+		javascript: () => import('shiki/langs/javascript.mjs'),
+	},
+	bundledThemes: {
+		'light-plus': () => import('shiki/themes/light-plus.mjs'),
+	},
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [],
+	plugins: [pluginShikiBundle<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromBundle(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-javascript-raw.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-javascript-raw.ts
@@ -1,0 +1,27 @@
+import { loadShikiThemeFromBundle, rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions, pluginShikiBundle, PluginShikiBundleOptions } from 'rehype-expressive-code'
+import { createJavaScriptRawEngine } from 'shiki/engine/javascript'
+
+type BundledLanguage = 'javascript'
+type BundledTheme = 'light-plus'
+
+const shikiOptions: PluginShikiBundleOptions<BundledLanguage, BundledTheme> = {
+	engine: createJavaScriptRawEngine,
+	bundledLangs: {
+		javascript: () => import('@shikijs/langs-precompiled/javascript'),
+	},
+	bundledThemes: {
+		'light-plus': () => import('shiki/themes/light-plus.mjs'),
+	},
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [],
+	plugins: [pluginShikiBundle<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromBundle(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-oniguruma.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/engine-oniguruma.ts
@@ -1,0 +1,27 @@
+import { loadShikiThemeFromBundle, rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions, pluginShikiBundle, PluginShikiBundleOptions } from 'rehype-expressive-code'
+import { createOnigurumaEngine } from 'shiki'
+
+type BundledLanguage = 'javascript'
+type BundledTheme = 'light-plus'
+
+const shikiOptions: PluginShikiBundleOptions<BundledLanguage, BundledTheme> = {
+	engine: createOnigurumaEngine,
+	bundledLangs: {
+		javascript: () => import('shiki/langs/javascript.mjs'),
+	},
+	bundledThemes: {
+		'light-plus': () => import('shiki/themes/light-plus.mjs'),
+	},
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [],
+	plugins: [pluginShikiBundle<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromBundle(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/no-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/no-themes.ts
@@ -1,0 +1,27 @@
+import { loadShikiThemeFromBundle, rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions, pluginShikiBundle, PluginShikiBundleOptions } from 'rehype-expressive-code'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+
+type BundledLanguage = 'javascript'
+type BundledTheme = 'light-plus'
+
+const shikiOptions: PluginShikiBundleOptions<BundledLanguage, BundledTheme> = {
+	engine: createJavaScriptRegexEngine,
+	bundledLangs: {
+		javascript: () => import('shiki/langs/javascript.mjs'),
+	},
+	bundledThemes: {
+		'light-plus': () => import('shiki/themes/light-plus.mjs'),
+	},
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [],
+	plugins: [pluginShikiBundle<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromBundle(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/with-themes-dynamic.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/with-themes-dynamic.ts
@@ -1,0 +1,27 @@
+import { loadShikiThemeFromBundle, rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions, pluginShikiBundle, PluginShikiBundleOptions } from 'rehype-expressive-code'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+
+type BundledLanguage = 'javascript'
+type BundledTheme = 'light-plus'
+
+const shikiOptions: PluginShikiBundleOptions<BundledLanguage, BundledTheme> = {
+	engine: createJavaScriptRegexEngine,
+	bundledLangs: {
+		javascript: () => import('shiki/langs/javascript.mjs'),
+	},
+	bundledThemes: {
+		'light-plus': () => import('shiki/themes/light-plus.mjs'),
+	},
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [(await import('shiki/themes/dracula.mjs')).default],
+	plugins: [pluginShikiBundle<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromBundle(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/with-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-bundle/with-themes.ts
@@ -1,0 +1,28 @@
+import { loadShikiThemeFromBundle, rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions, pluginShikiBundle, PluginShikiBundleOptions } from 'rehype-expressive-code'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+import dracula from 'shiki/themes/dracula.mjs'
+
+type BundledLanguage = 'javascript'
+type BundledTheme = 'light-plus'
+
+const shikiOptions: PluginShikiBundleOptions<BundledLanguage, BundledTheme> = {
+	engine: createJavaScriptRegexEngine,
+	bundledLangs: {
+		javascript: () => import('shiki/langs/javascript.mjs'),
+	},
+	bundledThemes: {
+		'light-plus': () => import('shiki/themes/light-plus.mjs'),
+	},
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [dracula],
+	plugins: [pluginShikiBundle<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromBundle(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/highlighter.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/highlighter.ts
@@ -1,0 +1,39 @@
+import type { DynamicImportLanguageRegistration, DynamicImportThemeRegistration, HighlighterGeneric } from 'shiki'
+import { createSingletonShorthands, createdBundledHighlighter, createJavaScriptRegexEngine } from 'shiki'
+
+type BundledLanguage = 'javascript'
+type BundledTheme = 'light-plus'
+type Highlighter = HighlighterGeneric<BundledLanguage, BundledTheme>
+
+const bundledLanguages: Record<BundledLanguage, DynamicImportLanguageRegistration> = {
+	javascript: () => import('shiki/langs/javascript.mjs'),
+}
+
+const bundledThemes: Record<BundledTheme, DynamicImportThemeRegistration> = {
+	'light-plus': () => import('shiki/themes/light-plus.mjs'),
+}
+
+const createHighlighter = /* @__PURE__ */ createdBundledHighlighter<BundledLanguage, BundledTheme>({
+	langs: bundledLanguages,
+	themes: bundledThemes,
+	engine: () => createJavaScriptRegexEngine(),
+})
+
+const { codeToHtml, codeToHast, codeToTokensBase, codeToTokens, codeToTokensWithThemes, getSingletonHighlighter, getLastGrammarState } = /* @__PURE__ */ createSingletonShorthands<
+	BundledLanguage,
+	BundledTheme
+>(createHighlighter)
+
+export {
+	bundledLanguages,
+	bundledThemes,
+	codeToHast,
+	codeToHtml,
+	codeToTokens,
+	codeToTokensBase,
+	codeToTokensWithThemes,
+	createHighlighter,
+	getLastGrammarState,
+	getSingletonHighlighter,
+}
+export type { BundledLanguage, BundledTheme, Highlighter }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/no-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/no-themes.ts
@@ -1,0 +1,24 @@
+import {
+	loadShikiThemeFromHighlighter,
+	rehypeExpressiveCodeCore,
+	RehypeExpressiveCodeCoreOptions,
+	pluginShikiWithHighlighter,
+	PluginShikiWithHighlighterOptions,
+} from 'rehype-expressive-code'
+import { getSingletonHighlighter, BundledLanguage, BundledTheme } from './highlighter'
+
+const shikiOptions: PluginShikiWithHighlighterOptions<BundledLanguage, BundledTheme> = {
+	highlighter: getSingletonHighlighter,
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [],
+	plugins: [pluginShikiWithHighlighter<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromHighlighter(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/with-themes-dynamic.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/with-themes-dynamic.ts
@@ -1,0 +1,24 @@
+import {
+	loadShikiThemeFromHighlighter,
+	rehypeExpressiveCodeCore,
+	RehypeExpressiveCodeCoreOptions,
+	pluginShikiWithHighlighter,
+	PluginShikiWithHighlighterOptions,
+} from 'rehype-expressive-code'
+import { getSingletonHighlighter, BundledLanguage, BundledTheme } from './highlighter'
+
+const shikiOptions: PluginShikiWithHighlighterOptions<BundledLanguage, BundledTheme> = {
+	highlighter: getSingletonHighlighter,
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [(await import('shiki/themes/dracula.mjs')).default],
+	plugins: [pluginShikiWithHighlighter<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromHighlighter(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/with-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core-highlighter/with-themes.ts
@@ -1,0 +1,25 @@
+import {
+	loadShikiThemeFromHighlighter,
+	rehypeExpressiveCodeCore,
+	RehypeExpressiveCodeCoreOptions,
+	pluginShikiWithHighlighter,
+	PluginShikiWithHighlighterOptions,
+} from 'rehype-expressive-code'
+import { getSingletonHighlighter, BundledLanguage, BundledTheme } from './highlighter'
+import dracula from 'shiki/themes/dracula.mjs'
+
+const shikiOptions: PluginShikiWithHighlighterOptions<BundledLanguage, BundledTheme> = {
+	highlighter: getSingletonHighlighter,
+}
+
+const options: RehypeExpressiveCodeCoreOptions<BundledTheme> = {
+	themes: [dracula],
+	plugins: [pluginShikiWithHighlighter<BundledLanguage, BundledTheme>(shikiOptions)],
+	customLoadTheme: (theme) => {
+		return loadShikiThemeFromHighlighter(shikiOptions, theme)
+	},
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core/no-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core/no-themes.ts
@@ -1,0 +1,9 @@
+import { rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions } from 'rehype-expressive-code'
+
+const options: RehypeExpressiveCodeCoreOptions = {
+	themes: [],
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core/with-themes-dynamic.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core/with-themes-dynamic.ts
@@ -1,0 +1,9 @@
+import { rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions } from 'rehype-expressive-code'
+
+const options: RehypeExpressiveCodeCoreOptions = {
+	themes: [(await import('shiki/themes/dracula.mjs')).default],
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core/with-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec-core/with-themes.ts
@@ -1,0 +1,10 @@
+import { rehypeExpressiveCodeCore, RehypeExpressiveCodeCoreOptions } from 'rehype-expressive-code'
+import dracula from 'shiki/themes/dracula.mjs'
+
+const options: RehypeExpressiveCodeCoreOptions = {
+	themes: [dracula],
+}
+
+const plugin = rehypeExpressiveCodeCore
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/no-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/no-themes.ts
@@ -1,0 +1,9 @@
+import { rehypeExpressiveCode, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
+
+const options: RehypeExpressiveCodeOptions = {
+	themes: [],
+}
+
+const plugin = rehypeExpressiveCode
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/shiki-false.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/shiki-false.ts
@@ -1,0 +1,9 @@
+import { rehypeExpressiveCode, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
+
+const options: RehypeExpressiveCodeOptions = {
+	shiki: false,
+}
+
+const plugin = rehypeExpressiveCode
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/with-themes-dynamic.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/with-themes-dynamic.ts
@@ -1,0 +1,9 @@
+import { rehypeExpressiveCode, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
+
+const options: RehypeExpressiveCodeOptions = {
+	themes: [(await import('shiki/themes/dracula.mjs')).default],
+}
+
+const plugin = rehypeExpressiveCode
+
+export { plugin, options }

--- a/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/with-themes.ts
+++ b/packages/rehype-expressive-code/test/fixtures/bundle-size/rehype-ec/with-themes.ts
@@ -1,0 +1,10 @@
+import { rehypeExpressiveCode, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
+import dracula from 'shiki/themes/dracula.mjs'
+
+const options: RehypeExpressiveCodeOptions = {
+	themes: [dracula],
+}
+
+const plugin = rehypeExpressiveCode
+
+export { plugin, options }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       '@internal/test-utils':
         specifier: workspace:^
         version: link:../../internal/test-utils
+      '@shikijs/langs-precompiled':
+        specifier: ^3.3.0
+        version: 3.3.0
       '@types/mdast':
         specifier: ^3.0.11
         version: 3.0.15
@@ -481,6 +484,12 @@ importers:
       remark-rehype:
         specifier: ^10.1.0
         version: 10.1.0
+      rollup-plugin-bundle-stats:
+        specifier: ^4.19.1
+        version: 4.19.1(core-js@3.41.0)(rollup@4.29.2)
+      rollup-plugin-visualizer:
+        specifier: ^5.14.0
+        version: 5.14.0(rollup@4.29.2)
       shiki:
         specifier: ^3.2.2
         version: 3.2.2
@@ -490,12 +499,18 @@ importers:
       vfile:
         specifier: ^6.0.1
         version: 6.0.1
+      vite:
+        specifier: ^6.0.7
+        version: 6.0.7(@types/node@20.17.11)(jiti@1.21.7)(yaml@2.7.0)
 
   packages/rehype-expressive-code/test/fixtures/nextjs:
     dependencies:
       '@expressive-code/plugin-collapsible-sections':
         specifier: workspace:^
         version: link:../../../../@expressive-code/plugin-collapsible-sections
+      '@expressive-code/plugin-shiki':
+        specifier: workspace:^
+        version: link:../../../../@expressive-code/plugin-shiki
       '@mdx-js/loader':
         specifier: ^3.1.0
         version: 3.1.0
@@ -992,6 +1007,30 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@bundle-stats/cli-utils@4.19.1':
+    resolution: {integrity: sha512-6qh6HQc919okDrMwJ3GpBszul3ZZuJqTfRbWp1t9z0UMPXcjlLgivk2ilxIAtqyIezIKN6plRGE8+Ix3Egr3sg==}
+    engines: {node: '>= 14.0'}
+
+  '@bundle-stats/html-templates@4.19.1':
+    resolution: {integrity: sha512-XrpdhF6kyrweynXjEiUrN/v397WFD1pJ1Wd0KB02DL8JmfIJ6OYUNVt/RjufmIOCI8yfCV/ysvCn1pubRk6J6A==}
+
+  '@bundle-stats/plugin-webpack-filter@4.19.1':
+    resolution: {integrity: sha512-6/Wn5/t3X4mqxn8TvxRQh2hBm294zI4STjliMcL36w1ap9Lw/CUcXuQwx/kCoTUC9JpncPlXus6Oht6/8Hs5zw==}
+    engines: {node: '>= 14.0'}
+    peerDependencies:
+      core-js: ^3.0.0
+
+  '@bundle-stats/plugin-webpack-validate@4.19.1':
+    resolution: {integrity: sha512-bzcYNovzZGGdrIW3blmomFBYTB6mgOoYrmb0CkbHxSXilk29mEb5msS+xqo51jhYzZ9wWoL8JnkWUgngbh12Wg==}
+    engines: {node: '>= 14.0'}
+
+  '@bundle-stats/utils@4.19.1':
+    resolution: {integrity: sha512-eSehoRZ/5pUVd6enDIx8w48k3vh80NgmdEVRVM4+HcCCReWqJfChioWI8dC+F6u+qlEWtKlHQoOa5/8uNcjnuQ==}
+    engines: {node: '>= 14.0'}
+    peerDependencies:
+      core-js: ^3.0.0
+      lodash: ^4.0.0
 
   '@changesets/apply-release-plan@7.0.7':
     resolution: {integrity: sha512-qnPOcmmmnD0MfMg9DjU1/onORFyRpDXkMMl2IJg9mECY6RnxL3wN0TCCc92b2sXt1jt8DgjAUUsZYGUGTdYIXA==}
@@ -1857,6 +1896,7 @@ packages:
   '@humanwhocodes/config-array@0.11.13':
     resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1864,6 +1904,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.1':
     resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
+    deprecated: Use @eslint/object-schema instead
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -2412,6 +2453,10 @@ packages:
   '@shikijs/engine-oniguruma@3.2.2':
     resolution: {integrity: sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==}
 
+  '@shikijs/langs-precompiled@3.3.0':
+    resolution: {integrity: sha512-2qsvPdopTt15OPzvDGYCl7gy08F7JN+EKLbo7DmhO/QchkYy2W4EltMpYKBz1KHP4136z3+Wt9QP9+2Rxfq7Yg==}
+    engines: {node: '>=20'}
+
   '@shikijs/langs@1.27.2':
     resolution: {integrity: sha512-MSrknKL0DbeXvhtSigMLIzjPOOQfvK7fsbcRv2NUUB0EvuTTomY8/U+lAkczYrXY2+dygKOapJKk8ScFYbtoNw==}
 
@@ -2438,6 +2483,9 @@ packages:
 
   '@shikijs/types@3.2.2':
     resolution: {integrity: sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==}
+
+  '@shikijs/types@3.3.0':
+    resolution: {integrity: sha512-KPCGnHG6k06QG/2pnYGbFtFvpVJmC3uIpXrAiPrawETifujPBv0Se2oUxm5qYgjCvGJS9InKvjytOdN+bGuX+Q==}
 
   '@shikijs/vscode-textmate@10.0.1':
     resolution: {integrity: sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==}
@@ -3145,6 +3193,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clsx@2.0.0:
     resolution: {integrity: sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==}
     engines: {node: '>=6'}
@@ -3190,8 +3242,11 @@ packages:
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
   concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -3217,6 +3272,9 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  core-js@3.41.0:
+    resolution: {integrity: sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==}
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -3354,6 +3412,10 @@ packages:
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -3706,10 +3768,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3842,6 +3900,7 @@ packages:
   eslint@8.53.0:
     resolution: {integrity: sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -3997,6 +4056,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+
   find-up-simple@1.0.0:
     resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
     engines: {node: '>=18'}
@@ -4070,6 +4133,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
@@ -4413,6 +4480,7 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4819,6 +4887,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   log-symbols@5.1.0:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
@@ -4872,6 +4943,10 @@ packages:
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -5482,17 +5557,24 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.0:
+    resolution: {integrity: sha512-fD9o5ebCmEAA9dLysajdQvuKzLL7cj+w7DQjuO3Cb6IwafENfx6iL+RGkmyW82pVRsvgzixsWinHvgxTMJvdIA==}
+
   oniguruma-parser@0.5.4:
     resolution: {integrity: sha512-yNxcQ8sKvURiTwP0mV6bLQCYE7NKfKRRWunhbZnXgxSmB1OXa1lHrN3o4DZd+0Si0kU5blidK7BcROO8qv5TZA==}
-
-  oniguruma-to-es@2.0.0:
-    resolution: {integrity: sha512-pE7+9jQgomy10aK6BJKRNHj1Nth0YLOzb3iRuhlz4gRzNSBSd7hga6U8BE6o0SoSuSkqv+PPtt511Msd1Hkl0w==}
 
   oniguruma-to-es@2.3.0:
     resolution: {integrity: sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==}
 
   oniguruma-to-es@4.1.0:
     resolution: {integrity: sha512-SNwG909cSLo4vPyyPbU/VJkEc9WOXqu2ycBlfd1UCXLqk1IijcQktSBb2yRQ2UFPsDhpkaf+C1dtT3PkLK/yWA==}
+
+  oniguruma-to-es@4.3.1:
+    resolution: {integrity: sha512-VtX1kepWO+7HG7IWV5v72JhiqofK7XsiHmtgnvurnNOTdIvE5mrdWYtsOrQyrXCv1L2Ckm08hywp+MFO7rC4Ug==}
+
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
 
   open@9.1.0:
     resolution: {integrity: sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==}
@@ -6017,6 +6099,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -6074,7 +6160,14 @@ packages:
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  rollup-plugin-bundle-stats@4.19.1:
+    resolution: {integrity: sha512-gnBjD8C2wAwwDMEr1lTe5cTzDBVw7voV8LLZeoqwB4WHVuRE3TbkUm94pxfUQfC3kmMSjaWppIbLSF4+ncaONQ==}
+    engines: {node: '>= 16.0'}
+    peerDependencies:
+      rollup: ^3.0.0 || ^4.0.0
 
   rollup-plugin-inject@3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
@@ -6082,6 +6175,31 @@ packages:
 
   rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
+
+  rollup-plugin-stats@1.3.4:
+    resolution: {integrity: sha512-N6PCNucOrRJxqzeAvpEyK9Wf4bxQlCCuIj5+n0XUB0plFU0u1VwjY0GDM6Z3lvs/KDhzJ2anYwxXUZVfmFw8LA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      rollup: ^3.0.0 || ^4.0.0
+
+  rollup-plugin-visualizer@5.14.0:
+    resolution: {integrity: sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      rolldown: 1.x
+      rollup: 2.x || 3.x || 4.x
+    peerDependenciesMeta:
+      rolldown:
+        optional: true
+      rollup:
+        optional: true
+
+  rollup-plugin-webpack-stats@2.0.3:
+    resolution: {integrity: sha512-tJJaYkP3yQctWRoAn7zh47DszOpwXVaDDmxriu48cohi7Nv/87l8Ry0vHnUd8e9MbpXuKZwEGQjqk1BjYLbYww==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      rollup: ^3.0.0 || ^4.0.0
 
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
@@ -6165,6 +6283,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  serialize-query-params@2.0.2:
+    resolution: {integrity: sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==}
+
   server-destroy@1.0.1:
     resolution: {integrity: sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==}
 
@@ -6214,6 +6335,7 @@ packages:
 
   shikiji@0.6.13:
     resolution: {integrity: sha512-4T7X39csvhT0p7GDnq9vysWddf2b6BeioiN3Ymhnt3xcy9tXmDcnsEFVxX18Z4YcQgEE/w48dLJ4pPPUcG9KkA==}
+    deprecated: Deprecated, use shiki instead
 
   side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -6329,6 +6451,15 @@ packages:
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
+
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-chain@3.4.0:
+    resolution: {integrity: sha512-cyDiaDqAfgmeiv0PWFXCg9oKNVYNzYxHK9j5CMsYMHZDk+/yYcSV+CXQZliZ0U4mNU8DLqiVNZXUfs8BqhgwMw==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
 
   stream-parser@0.3.1:
     resolution: {integrity: sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==}
@@ -6462,6 +6593,10 @@ packages:
   summer-time@3.1.7:
     resolution: {integrity: sha512-HcpPyuO1XhILgvBKddmPc1rHcxdsdjHB4NFDAqjg/UFdgRv+Ms7ma9mzfZYVrqseUbHo6GyBP+M3jQggzTq8ng==}
     engines: {vscode: ^1.15.0}
+
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -7220,6 +7355,7 @@ packages:
   wrangler@3.100.0:
     resolution: {integrity: sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==}
     engines: {node: '>=16.17.0'}
+    deprecated: Downgrade to 3.99.0
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20241230.0
@@ -7272,6 +7408,10 @@ packages:
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -7285,6 +7425,10 @@ packages:
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
@@ -8149,6 +8293,39 @@ snapshots:
       '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@bundle-stats/cli-utils@4.19.1(core-js@3.41.0)':
+    dependencies:
+      '@bundle-stats/html-templates': 4.19.1
+      '@bundle-stats/plugin-webpack-filter': 4.19.1(core-js@3.41.0)
+      '@bundle-stats/utils': 4.19.1(core-js@3.41.0)(lodash@4.17.21)
+      find-cache-dir: 3.3.2
+      lodash: 4.17.21
+      stream-chain: 3.4.0
+      stream-json: 1.9.1
+    transitivePeerDependencies:
+      - core-js
+
+  '@bundle-stats/html-templates@4.19.1': {}
+
+  '@bundle-stats/plugin-webpack-filter@4.19.1(core-js@3.41.0)':
+    dependencies:
+      core-js: 3.41.0
+      tslib: 2.8.1
+
+  '@bundle-stats/plugin-webpack-validate@4.19.1':
+    dependencies:
+      lodash: 4.17.21
+      superstruct: 2.0.2
+      tslib: 2.8.1
+
+  '@bundle-stats/utils@4.19.1(core-js@3.41.0)(lodash@4.17.21)':
+    dependencies:
+      '@bundle-stats/plugin-webpack-filter': 4.19.1(core-js@3.41.0)
+      '@bundle-stats/plugin-webpack-validate': 4.19.1
+      core-js: 3.41.0
+      lodash: 4.17.21
+      serialize-query-params: 2.0.2
 
   '@changesets/apply-release-plan@7.0.7':
     dependencies:
@@ -9083,7 +9260,7 @@ snapshots:
       is-glob: 4.0.3
       open: 9.1.0
       picocolors: 1.0.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@rollup/pluginutils@5.1.0(rollup@4.29.2)':
     dependencies:
@@ -9227,7 +9404,7 @@ snapshots:
       '@shikijs/engine-javascript': 1.27.2
       '@shikijs/engine-oniguruma': 1.27.2
       '@shikijs/types': 1.27.2
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.4
 
@@ -9236,7 +9413,7 @@ snapshots:
       '@shikijs/engine-javascript': 2.0.3
       '@shikijs/engine-oniguruma': 2.0.3
       '@shikijs/types': 2.0.3
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.4
 
@@ -9250,13 +9427,13 @@ snapshots:
   '@shikijs/engine-javascript@1.27.2':
     dependencies:
       '@shikijs/types': 1.27.2
-      '@shikijs/vscode-textmate': 10.0.1
-      oniguruma-to-es: 2.0.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 2.3.0
 
   '@shikijs/engine-javascript@2.0.3':
     dependencies:
       '@shikijs/types': 2.0.3
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 2.3.0
 
   '@shikijs/engine-javascript@3.2.2':
@@ -9268,17 +9445,22 @@ snapshots:
   '@shikijs/engine-oniguruma@1.27.2':
     dependencies:
       '@shikijs/types': 1.27.2
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@shikijs/engine-oniguruma@2.0.3':
     dependencies:
       '@shikijs/types': 2.0.3
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
 
   '@shikijs/engine-oniguruma@3.2.2':
     dependencies:
       '@shikijs/types': 3.2.2
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs-precompiled@3.3.0':
+    dependencies:
+      '@shikijs/types': 3.3.0
+      oniguruma-to-es: 4.3.1
 
   '@shikijs/langs@1.27.2':
     dependencies:
@@ -9306,15 +9488,20 @@ snapshots:
 
   '@shikijs/types@1.27.2':
     dependencies:
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
   '@shikijs/types@2.0.3':
     dependencies:
-      '@shikijs/vscode-textmate': 10.0.1
+      '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
   '@shikijs/types@3.2.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@3.3.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -10557,7 +10744,7 @@ snapshots:
   capnp-ts@0.7.0:
     dependencies:
       debug: 4.3.7
-      tslib: 2.6.2
+      tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10651,6 +10838,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.0.0: {}
 
   clsx@2.1.1: {}
@@ -10687,6 +10880,8 @@ snapshots:
 
   common-ancestor-path@1.0.1: {}
 
+  commondir@1.0.1: {}
+
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
@@ -10702,6 +10897,8 @@ snapshots:
   cookie@0.6.0: {}
 
   cookie@0.7.2: {}
+
+  core-js@3.41.0: {}
 
   cross-spawn@7.0.3:
     dependencies:
@@ -10823,6 +11020,8 @@ snapshots:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
+
+  define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
 
@@ -11316,8 +11515,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.24.2
       '@esbuild/win32-x64': 0.24.2
 
-  escalade@3.1.1: {}
-
   escalade@3.2.0: {}
 
   escape-string-regexp@1.0.5: {}
@@ -11735,6 +11932,12 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-cache-dir@3.3.2:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+
   find-up-simple@1.0.0: {}
 
   find-up@4.1.0:
@@ -11810,6 +12013,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.2.0: {}
 
@@ -12789,6 +12994,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  lodash@4.17.21: {}
+
   log-symbols@5.1.0:
     dependencies:
       chalk: 5.3.0
@@ -12846,6 +13053,10 @@ snapshots:
       '@babel/parser': 7.26.5
       '@babel/types': 7.26.5
       source-map-js: 1.2.1
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
 
   make-dir@4.0.0:
     dependencies:
@@ -14059,13 +14270,9 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  oniguruma-parser@0.5.4: {}
+  oniguruma-parser@0.12.0: {}
 
-  oniguruma-to-es@2.0.0:
-    dependencies:
-      emoji-regex-xs: 1.0.0
-      regex: 5.1.1
-      regex-recursion: 5.1.1
+  oniguruma-parser@0.5.4: {}
 
   oniguruma-to-es@2.3.0:
     dependencies:
@@ -14079,6 +14286,18 @@ snapshots:
       oniguruma-parser: 0.5.4
       regex: 6.0.1
       regex-recursion: 6.0.2
+
+  oniguruma-to-es@4.3.1:
+    dependencies:
+      oniguruma-parser: 0.12.0
+      regex: 6.0.1
+      regex-recursion: 6.0.2
+
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   open@9.1.0:
     dependencies:
@@ -14799,6 +15018,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
@@ -14885,6 +15106,15 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
+  rollup-plugin-bundle-stats@4.19.1(core-js@3.41.0)(rollup@4.29.2):
+    dependencies:
+      '@bundle-stats/cli-utils': 4.19.1(core-js@3.41.0)
+      rollup: 4.29.2
+      rollup-plugin-webpack-stats: 2.0.3(rollup@4.29.2)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - core-js
+
   rollup-plugin-inject@3.0.2:
     dependencies:
       estree-walker: 0.6.1
@@ -14894,6 +15124,24 @@ snapshots:
   rollup-plugin-node-polyfills@0.2.1:
     dependencies:
       rollup-plugin-inject: 3.0.2
+
+  rollup-plugin-stats@1.3.4(rollup@4.29.2):
+    dependencies:
+      rollup: 4.29.2
+
+  rollup-plugin-visualizer@5.14.0(rollup@4.29.2):
+    dependencies:
+      open: 8.4.2
+      picomatch: 4.0.2
+      source-map: 0.7.4
+      yargs: 17.7.2
+    optionalDependencies:
+      rollup: 4.29.2
+
+  rollup-plugin-webpack-stats@2.0.3(rollup@4.29.2):
+    dependencies:
+      rollup: 4.29.2
+      rollup-plugin-stats: 1.3.4(rollup@4.29.2)
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -15022,6 +15270,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.6.3: {}
+
+  serialize-query-params@2.0.2: {}
 
   server-destroy@1.0.1: {}
 
@@ -15267,6 +15517,14 @@ snapshots:
 
   stoppable@1.1.0: {}
 
+  stream-chain@2.2.5: {}
+
+  stream-chain@3.4.0: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
+
   stream-parser@0.3.1:
     dependencies:
       debug: 2.6.9
@@ -15431,6 +15689,8 @@ snapshots:
       ts-interface-checker: 0.1.13
 
   summer-time@3.1.7: {}
+
+  superstruct@2.0.2: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -15601,8 +15861,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsm@2.3.0:
     dependencies:
@@ -15917,7 +16176,7 @@ snapshots:
   update-browserslist-db@1.0.11(browserslist@4.21.10):
     dependencies:
       browserslist: 4.21.10
-      escalade: 3.1.1
+      escalade: 3.2.0
       picocolors: 1.1.1
 
   update-browserslist-db@1.1.1(browserslist@4.24.2):
@@ -16272,6 +16531,8 @@ snapshots:
 
   xxhash-wasm@1.1.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
@@ -16279,6 +16540,16 @@ snapshots:
   yaml@2.7.0: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
As discussed in #326, other than for `astro-expressive-code`, there is no current way to control the bundle size when using `expressive-code` outside of some `package.json` related workarounds.  This PR aims to address that by providing stock support for controlling bundle size by introducing a new `Core` concept across the various packages (e.g., `ExpressiveCodeCore`, `RehypeExpressiveCodeCore`, etc.).

> [!NOTE]
> The approach taken in this PR is to ensure 100% backwards compatibility with v0.41.2.  All existing tests pass without any modification.  If it's acceptable to introduce some minor adjustments, the current approach can be simplified in some areas. Since `expressive-code` uses semver `0.x.x`, technically every release is a breaking change so for the purposes of long-term maintenance, some changes may be worth considering.

## TLDR;

| 0 lang / 0 theme                                | Full Bundle | Shiki     | PluginShiki | PluginFrames | PluginTextMarkers |
| ----------------------------------- | ----------- | --------- | ----------- | ---------------- | --------------------- |
| v0.41.2                           | 9,577,922   | 9,695,299 | 20,365      | 23,186           | 22,246                |
| Core No Plugins                     | 347,138     | 0         | 0           | 3,788            | 2,367                 |
| Savings                             | 9,230,784   | 9,695,299 | 20,365      | 19,398           | 19,879                |

| 1 lang / 1 theme                                | Full Bundle | Shiki     | PluginShiki | PluginFrames | PluginTextMarkers |
| ----------------------------------- | ----------- | --------- | ----------- | ---------------- | --------------------- |
| v0.41.2                           | 9,577,922   | 9,695,299 | 20,365      | 23,186           | 22,246                |
| Core Bundle | 780,831     | 358,594   | 20,179      | 3,788            | 2,367                 |
| Savings                             | 8,797,091   | 9,336,705 | 186         | 19,398           | 19,879                |

| 1 lang / 1 theme                                | Full Bundle | Shiki     | PluginShiki | PluginFrames | PluginTextMarkers |
| ----------------------------------- | ----------- | --------- | ----------- | ---------------- | --------------------- |
| v0.41.2                           | 9,577,922   | 9,695,299 | 20,365      | 23,186           | 22,246                |
| Core Highlighter | 781,711     | 360,766   | 18,950      | 3,788            | 2,367                 |
| Savings                             | 8,796,211   | 9,334,533 | 1,415       | 19,398           | 19,879                |

1. Setting `shiki=false` in configuration makes no difference to final bundle size when using `ExpressiveCode/rehypeExpressiveCode/createRenderer`, to reduce bundle size, you must use `Core` directly
2. Shiki & Plugin* columns are `renderedLength` of corresponding item, the `Full Bundle` column is the actual final size of the module on disk
3. The reason `PluginFrames` and `PluginTextMarkers` are not zero in `Core` is primarily due to styles (css) which could likely be refactored out

## Additional Information
1. `remark-expressive-code` appears to be deprecated so it was not updated for `Core`
2. `astro-expressive-code` needs to be updated to `Core`. Once a decision is made on potentially incorporating this PR and the `Core` API finalized, I'll look at updating it to use `Core` rather than its `vite-plugin` approach.
3. I've added a few comments to code in this PR to highlight some things that should be specifically evaluated/considered outside of the general PR itself
4. The [bundle-size tests](packages/rehype-expressive-code/test/bundle-size.test.ts) generate builds across the different variants of `RehypeExpressiveCode` and `RehypeExpressiveCodeCore`.  In `dist` folder of each fixture are statistics files that can be reviewed for detailed information about the build output.  See [visualizer](https://github.com/expressive-code/expressive-code/compare/main...techfg:expressive-code:feat/support-controlling-bundle-size?expand=1#diff-c27836fbe666b134979131fe3f1fff2d576e70424548e8e1346a95b9cb764fccR96) and [bundle-stats](https://github.com/expressive-code/expressive-code/compare/main...techfg:expressive-code:feat/support-controlling-bundle-size?expand=1#diff-c27836fbe666b134979131fe3f1fff2d576e70424548e8e1346a95b9cb764fccR106) for more information.  

Open to any and all feedback, appreciate your consideration!

Resolves #326 
