### PR TITLE
feat: add support for processing inline code

### DIFF
--- a/docs/ec.config.mjs
+++ b/docs/ec.config.mjs
@@ -20,4 +20,5 @@ export default defineEcConfig({
 	defaultProps: {
 		showLineNumbers: false,
 	},
+	inline: 'trailing-curly-colon'
 })

--- a/docs/scripts/typedoc/templates/key-features/frames.mdx
+++ b/docs/scripts/typedoc/templates/key-features/frames.mdx
@@ -13,6 +13,10 @@ Frames can have optional titles, which are either taken from the code block's me
 These features are provided by `@expressive-code/plugin-frames`, which is installed & enabled by default in all framework integrations. You can start using it right away in your documents!
 :::
 
+:::note[Code Block type support]
+Does not support `inline` code blocks.
+:::
+
 ## Usage in markdown / MDX
 
 ### Code editor frames

--- a/docs/scripts/typedoc/templates/key-features/text-markers.mdx
+++ b/docs/scripts/typedoc/templates/key-features/text-markers.mdx
@@ -12,6 +12,10 @@ Expressive Code allows you to add annotations to lines & line ranges, as well as
 These features are provided by `@expressive-code/plugin-text-markers`, which is installed & enabled by default in all framework integrations. You can start using it right away in your documents!
 :::
 
+:::note[Code Block type support]
+Does not support `inline` code blocks.
+:::
+
 ## Usage in markdown / MDX
 
 ### Marking full lines & line ranges

--- a/docs/scripts/typedoc/templates/plugins/collapsible-sections.mdx
+++ b/docs/scripts/typedoc/templates/plugins/collapsible-sections.mdx
@@ -10,6 +10,10 @@ This optional plugin allows you to reduce long code examples to their relevant p
 
 The lines of collapsed sections will be replaced by a clickable `X collapsed lines` element. When clicked, the collapsed section will be expanded, showing the previously hidden lines.
 
+:::note[Code Block type support]
+Does not support `inline` code blocks.
+:::
+
 ## Installation
 
 Before being able to use collapsible sections in your code blocks, you need to install the plugin as a dependency and add it to your configuration:

--- a/docs/scripts/typedoc/templates/plugins/line-numbers.mdx
+++ b/docs/scripts/typedoc/templates/plugins/line-numbers.mdx
@@ -8,6 +8,10 @@ import { Steps, Tabs, TabItem } from '@astrojs/starlight/components'
 
 This optional plugin allows you to display line numbers in your code blocks. The line numbers are displayed in the gutter to the left of the code.
 
+:::note[Code Block type support]
+Does not support `inline` code blocks.
+:::
+
 ## Installation
 
 Before being able to display line numbers in your code blocks, you need to install the plugin as a dependency and add it to your configuration:

--- a/docs/scripts/typedoc/templates/reference/configuration.mdx
+++ b/docs/scripts/typedoc/templates/reference/configuration.mdx
@@ -345,6 +345,14 @@ This plugin is enabled by default. Set this to `false` to disable it.
 
 In addition to the options above, the rehype integration also supports the following options:
 
+:::tip[Detecting code block type and language]
+When a code block is detected by Expressive Code, the `<code>` element will be wrapped in a `<pre>` (for `block` code) or `<span>` (for `inline` code) element that will contain the following data attributes which can be helpful for conditional
+handling in downstream processing (e.g., `CSS`, `react-markdown`, etc.):
+
+- `data-language`: syntax highlighting language (e.g., `js`)
+- `data-ec-type`: `block` or `inline`
+:::
+
 ### customCreateBlock
 
 <PropertySignature>
@@ -397,6 +405,26 @@ If the function returns `undefined`, the default locale provided in the Expressi
 
 - **file**: VFileWithOutput\<null\>\
   A `VFile` instance representing the Markdown document.
+
+### inline
+
+<PropertySignature>
+- Type: false \| `'trailing-curly-colon'` \| undefined
+- Default: `false`
+</PropertySignature>
+
+Enable inline code to be processed.
+
+Supported Language Identifier Formats:
+- `trailing-curly-colon`: Append a `\{:lang}` marker at the end of the inline code (e.g., `code\{:lang}`). The 
+   `trailing-curly-colon` can be escaped with `\` to bypass processing and any backslashes intended to be 
+   rendered just prior to the `trailing-curly-colon` should be escaped (e.g., `\\`):
+    - Enabled:
+	      - `doWork()\{:js}` -> `doWork(){:js}`
+	      - `doWork()\\\\\{:js}` -> `doWork()\\{:js}`
+    - Disabled:
+        - `doWork()\\\{:js}` -> `doWork()\{:js}`
+        - `doWork()\\\\\\\{:js}` -> `doWork()\\\{:js}`
 
 ### tabWidth
 

--- a/docs/src/content/docs/key-features/syntax-highlighting.mdx
+++ b/docs/src/content/docs/key-features/syntax-highlighting.mdx
@@ -97,6 +97,18 @@ Result:
 - [9mStrikethrough[0m
 ```
 
+### Inline Syntax Highlighting
+
+To get syntax highlighting for inline code, wrap it in single backticks and ensure that it includes a language identifier that corresponds to the [inline option](/reference/configuration/#inline) specified in the configuration.
+
+```md title="example.md"
+Inline code example `console.log('Hello!'){:js}` for syntax highlighting.
+```
+
+The rendered result looks like this:
+
+Inline code example `console.log('Hello!'){:js}` for syntax highlighting.
+
 ## Supported languages
 
 Out of the box, over 100 languages are supported, including JavaScript, TypeScript, HTML, CSS, Astro, Markdown, MDX, JSON, YAML, and many more. You can find a [list of all language identifiers](https://github.com/antfu/textmate-grammars-themes/blob/main/packages/tm-grammars/README.md) on GitHub.

--- a/docs/src/content/docs/key-features/word-wrap.mdx
+++ b/docs/src/content/docs/key-features/word-wrap.mdx
@@ -11,6 +11,10 @@ When your code blocks contain long lines, it can be helpful to enable word wrap 
 This feature is provided by the Expressive Code core package. You can start using it right away in your documents!
 :::
 
+:::note[Code Block type support]
+Does not support `inline` code blocks.
+:::
+
 ## Usage in markdown / MDX
 
 ### Configuring word wrap per block

--- a/internal/test-utils/src/html-snapshots.ts
+++ b/internal/test-utils/src/html-snapshots.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from 'fs'
 import { join, dirname } from 'path'
-import { ExpressiveCodeEngine, ExpressiveCodeEngineConfig, ExpressiveCodePlugin, ExpressiveCodeTheme, StyleVariant } from '@expressive-code/core'
+import { type ExpressiveCodeBlockType, ExpressiveCodeEngine, ExpressiveCodeEngineConfig, ExpressiveCodePlugin, ExpressiveCodeTheme, StyleVariant } from '@expressive-code/core'
 import type { Element } from '@expressive-code/core/hast'
 import { toHtml } from '@expressive-code/core/hast'
 
@@ -13,6 +13,7 @@ export type TestFixture = {
 	meta?: string | undefined
 	themes?: ExpressiveCodeTheme[] | undefined
 	plugins: ExpressiveCodePlugin[]
+	type?: ExpressiveCodeBlockType | undefined
 	engineOptions?: Partial<ExpressiveCodeEngineConfig> | undefined
 	blockValidationFn?: BlockValidationFn | undefined
 }
@@ -26,7 +27,7 @@ export function buildThemeFixtures(themes: ExpressiveCodeTheme[], fixtureContent
 	return [fixture]
 }
 
-async function renderFixture({ fixtureName, code, language = 'js', meta = '', themes, plugins, engineOptions, blockValidationFn }: TestFixture) {
+async function renderFixture({ fixtureName, code, language = 'js', meta = '', themes, plugins, engineOptions, blockValidationFn, type }: TestFixture) {
 	const engine = new ExpressiveCodeEngine({
 		themes,
 		plugins,
@@ -39,6 +40,7 @@ async function renderFixture({ fixtureName, code, language = 'js', meta = '', th
 		code,
 		language,
 		meta,
+		type,
 	})
 
 	return {

--- a/packages/@expressive-code/core/src/common/plugin.ts
+++ b/packages/@expressive-code/core/src/common/plugin.ts
@@ -1,3 +1,4 @@
+import { type ExpressiveCodeBlockType } from './block'
 import { ExpressiveCodePluginHooks } from './plugin-hooks'
 import { PluginStyleSettings } from './plugin-style-settings'
 import { StyleSettingPath } from './style-settings'
@@ -58,6 +59,15 @@ export interface ExpressiveCodePlugin {
 	 * rendering process. See {@link ExpressiveCodePluginHooks} for a list of available hooks.
 	 */
 	hooks?: ExpressiveCodePluginHooks | undefined
+	/**
+	 * The code block types that are supported by the plugin.
+	 *
+	 * In order for the plugins hooks to be called for a code block with a given type,
+	 * the type must be listed here.
+	 *
+	 * @default [`block`].
+	 */
+	supportedCodeBlockTypes?: ExpressiveCodeBlockType[] | undefined
 }
 
 export type BaseStylesResolverFn = (context: ResolverContext) => string | Promise<string>

--- a/packages/@expressive-code/core/src/common/style-settings.ts
+++ b/packages/@expressive-code/core/src/common/style-settings.ts
@@ -86,4 +86,11 @@ export function getCssVarName(styleSetting: StyleSettingPath) {
 	return `--ec-${varName}`
 }
 
-export const codeLineClass = 'ec-line'
+export const codeBlockLineClass = 'ec-line'
+export const inlineCodeLineClass = 'ec-line-inline'
+/** @deprecated Use {@link codeBlockLineClass} or {@link inlineCodeLineClass} instead. */
+export const codeLineClass = codeBlockLineClass
+
+export const containerBlockClass = 'ec-container-block'
+export const containerInlineClass = 'ec-container-inline'
+export const containerMixedClass = 'ec-container-mixed'

--- a/packages/@expressive-code/core/src/internal/core-styles.ts
+++ b/packages/@expressive-code/core/src/internal/core-styles.ts
@@ -1,7 +1,7 @@
 import { lighten, ensureColorContrastOnBackground, setAlpha } from '../helpers/color-transforms'
 import { ResolverContext } from '../common/plugin'
 import { PluginStyleSettings } from '../common/plugin-style-settings'
-import { UnresolvedStyleSettings, codeLineClass } from '../common/style-settings'
+import { UnresolvedStyleSettings, containerBlockClass, containerInlineClass, codeBlockLineClass, inlineCodeLineClass } from '../common/style-settings'
 
 export interface CoreStyleSettings {
 	/**
@@ -232,12 +232,14 @@ export function getCoreBaseStyles({
 	const ifThemedSelectionColors = (css: string) => (useThemedSelectionColors ? css : '')
 
 	return `
-		font-family: ${cssVar('uiFontFamily')};
-		font-size: ${cssVar('uiFontSize')};
-		font-weight: ${cssVar('uiFontWeight')};
-		line-height: ${cssVar('uiLineHeight')};
-		text-size-adjust: none;
-		-webkit-text-size-adjust: none;
+		&.${containerBlockClass}, .${containerBlockClass} {
+			font-family: ${cssVar('uiFontFamily')};
+			font-size: ${cssVar('uiFontSize')};
+			font-weight: ${cssVar('uiFontWeight')};
+			line-height: ${cssVar('uiLineHeight')};
+			text-size-adjust: none;
+			-webkit-text-size-adjust: none;
+		}
 
 		*:not(:is(svg, svg *)) {
 			${useStyleReset ? 'all: revert;' : ''}
@@ -248,6 +250,13 @@ export function getCoreBaseStyles({
 			background: ${cssVar('uiSelectionBackground')};
 			color: ${cssVar('uiSelectionForeground')};
 		}`)}
+
+		&.${containerInlineClass}, .${containerInlineClass} {
+			& > span > code {
+				background: ${cssVar('codeBackground')};
+				color: ${cssVar('codeForeground')};
+			}			
+		}
 
 		pre {
 			display: flex;
@@ -285,7 +294,7 @@ export function getCoreBaseStyles({
 			overflow-x: auto;
 
 			/* Enable word wrapping on demand */
-			&.wrap .${codeLineClass} .code {
+			&.wrap .${codeBlockLineClass} .code {
 				white-space: pre-wrap;
 				overflow-wrap: break-word;
 				min-width: min(20ch, var(--ecMaxLine, 20ch));
@@ -315,7 +324,7 @@ export function getCoreBaseStyles({
 		}
 
 		/* Code lines */
-		.${codeLineClass} {
+		.${codeBlockLineClass} {
 			/* RTL support: Code is always LTR */
 			direction: ltr;
 			unicode-bidi: isolate;
@@ -385,7 +394,7 @@ export function getCoreBaseStyles({
 export function getCoreThemeStyles(styleVariantIndex: number) {
 	return `
 		/* Theme-dependent styles for InlineStyleAnnotation */
-		.${codeLineClass} :where(span[style^='--']:not([class])) {
+		:is(.${codeBlockLineClass}, .${inlineCodeLineClass}) :where(span[style^='--']:not([class])) {
 			color: var(--${styleVariantIndex}, inherit);
 			background-color: var(--${styleVariantIndex}bg, transparent);
 			font-style: var(--${styleVariantIndex}fs, inherit);

--- a/packages/@expressive-code/core/src/internal/css.ts
+++ b/packages/@expressive-code/core/src/internal/css.ts
@@ -2,8 +2,15 @@ import postcss, { Root } from 'postcss'
 import postcssNested from 'postcss-nested'
 import { escapeRegExp } from './escaping'
 
-export const groupWrapperElement = 'div'
+export const groupBlockWrapperElement = 'div'
+export const groupInlineWrapperElement = 'span'
+export const groupMixedWrapperElement = 'div'
+/** @deprecated Use {@link groupBlockWrapperElement}, {@link groupInlineWrapperElement}, or {@link groupMixedWrapperElement} instead. */
+export const groupWrapperElement = groupBlockWrapperElement
 export const groupWrapperClassName = 'expressive-code'
+
+export const containerBlockElement = 'div'
+export const containerInlineElement = 'span'
 
 /**
  * A map of long terms commonly found in style setting paths to shorter alternatives that are

--- a/packages/@expressive-code/core/src/internal/type-checks.ts
+++ b/packages/@expressive-code/core/src/internal/type-checks.ts
@@ -24,6 +24,10 @@ export function isHastElement(node: Node) {
 	return isHastNode(node) && node.type === 'element'
 }
 
+export function isValidCodeBlockType(type: string) {
+	return type === 'inline' || type === 'block'
+}
+
 export function newTypeError(expectedTypeDescription: string, actualValue: unknown, fieldName?: string) {
 	return new Error(`${fieldName ? `Invalid ${fieldName} value: ` : ''}Expected a valid ${expectedTypeDescription}, but got ${JSON.stringify(actualValue)}`)
 }

--- a/packages/@expressive-code/core/test/block.test.ts
+++ b/packages/@expressive-code/core/test/block.test.ts
@@ -9,8 +9,10 @@ describe('ExpressiveCodeBlock', () => {
 			const invalidFirstArgContents = nonStringValues.flatMap((value) => [
 				{ code: value, language: '', meta: '' },
 				{ code: '', language: value, meta: '' },
-				// Meta can be undefined, so pass another invalid value in this case
+				// Meta & Type can be undefined, so pass another invalid value in this case
 				{ code: '', language: '', meta: value !== undefined ? value : false },
+				{ code: '', language: '', meta: '', type: value !== undefined ? value : false },
+				{ code: '', language: '', meta: '', type: 'invalid' },
 			])
 			const invalidArgs = [...invalidFirstArgTypes, ...invalidFirstArgContents]
 
@@ -68,15 +70,30 @@ describe('ExpressiveCodeBlock', () => {
 	})
 
 	describe('getLines()', () => {
-		test('Returns no lines if no code was passed to constructor', () => {
+		test('Returns no lines if no code was passed to constructor for code block', () => {
 			const block = new ExpressiveCodeBlock({ code: '', language: '', meta: '' })
 			expect(block.getLines()).toHaveLength(0)
 		})
-		test('Returns the code passed to the constructor split into lines', () => {
+		test('Returns no lines if no code was passed to constructor for inline code', () => {
+			const block = new ExpressiveCodeBlock({ code: '', language: '', meta: '', type: 'inline' })
+			expect(block.getLines()).toHaveLength(0)
+		})
+		test('Returns the code passed to the constructor split into lines for code block', () => {
 			const testLines = ['This is great!', '', 'It seems to work.']
 			const lineEndings = ['\n', '\r\n']
 			lineEndings.forEach((lineEnding) => {
 				const block = new ExpressiveCodeBlock({ code: testLines.join(lineEnding), language: '', meta: '' })
+				expect(
+					block.getLines().map((line) => line.text),
+					`Failed when using line ending ${JSON.stringify(lineEnding)}`
+				).toMatchObject(testLines)
+			})
+		})
+		test('Returns the code passed to the constructor split into lines for inline code', () => {
+			const testLines = ['This is great!', '', 'It seems to work.']
+			const lineEndings = ['\n', '\r\n']
+			lineEndings.forEach((lineEnding) => {
+				const block = new ExpressiveCodeBlock({ code: testLines.join(lineEnding), language: '', meta: '', type: 'inline' })
 				expect(
 					block.getLines().map((line) => line.text),
 					`Failed when using line ending ${JSON.stringify(lineEnding)}`

--- a/packages/@expressive-code/core/test/plugin-hooks.test.ts
+++ b/packages/@expressive-code/core/test/plugin-hooks.test.ts
@@ -13,7 +13,7 @@ import {
 } from './utils'
 import { ExpressiveCodePluginHookName } from '../src/common/plugin-hooks'
 import { ExpressiveCodeProcessingState } from '../src/internal/render-block'
-import { groupWrapperElement } from '../src/internal/css'
+import { groupBlockWrapperElement } from '../src/internal/css'
 
 describe('Block-level hooks are called with the correct processing state', () => {
 	const baseState: ExpressiveCodeProcessingState = {
@@ -282,12 +282,12 @@ describe('Rendering hooks allow post-processing ASTs', () => {
 			expect(html).toEqual(
 				[
 					// Start of group wrapper
-					`<${groupWrapperElement}>`,
+					`<${groupBlockWrapperElement}>`,
 					'<figure>',
 					`<pre><code><div>${lineCodeHtml[0]}</div><div>${lineCodeHtml[1]}</div></code></pre>`,
 					'</figure>',
 					// End of group wrapper
-					`</${groupWrapperElement}>`,
+					`</${groupBlockWrapperElement}>`,
 				].join('')
 			)
 		})
@@ -310,7 +310,7 @@ describe('Rendering hooks allow post-processing ASTs', () => {
 			expect(html).toEqual(
 				[
 					// Start of group wrapper
-					`<${groupWrapperElement}>`,
+					`<${groupBlockWrapperElement}>`,
 					// Wrapper added by hook around first child
 					'<figure>',
 					`<pre><code><div>${lineCodeHtml[0]}</div><div>${lineCodeHtml[1]}</div></code></pre>`,
@@ -320,7 +320,7 @@ describe('Rendering hooks allow post-processing ASTs', () => {
 					'<pre><code><div><div class="code">Just one line here!</div></div></code></pre>',
 					'</figure>',
 					// End of group wrapper
-					`</${groupWrapperElement}>`,
+					`</${groupBlockWrapperElement}>`,
 				].join('')
 			)
 		})
@@ -355,11 +355,11 @@ describe('Rendering hooks allow post-processing ASTs', () => {
 					// Wrapper added by hook
 					'<details test="1">',
 					// Start of group wrapper
-					`<${groupWrapperElement}>`,
+					`<${groupBlockWrapperElement}>`,
 					// Regular code block HTML
 					`<pre><code><div>${lineCodeHtml[0]}</div><div>${lineCodeHtml[1]}</div></code></pre>`,
 					// End of group wrapper
-					`</${groupWrapperElement}>`,
+					`</${groupBlockWrapperElement}>`,
 					// End of wrapper added by hook
 					'</details>',
 				].join('')
@@ -437,7 +437,7 @@ describe('Rendering hooks allow post-processing ASTs', () => {
 					// Wrapper added by second hook
 					'<details test="2" edited="3">',
 					// Start of group wrapper
-					`<${groupWrapperElement}>`,
+					`<${groupBlockWrapperElement}>`,
 					// Figure added by first hook
 					'<figure test="1">',
 					// Regular code block HTML
@@ -445,7 +445,7 @@ describe('Rendering hooks allow post-processing ASTs', () => {
 					// End of figure added by first hook
 					'</figure>',
 					// End of group wrapper
-					`</${groupWrapperElement}>`,
+					`</${groupBlockWrapperElement}>`,
 					// End of wrapper added by second hook
 					'</details>',
 				].join('')

--- a/packages/@expressive-code/core/test/render-line.test.ts
+++ b/packages/@expressive-code/core/test/render-line.test.ts
@@ -3,7 +3,7 @@ import type { Parents } from '../src/hast'
 import { toHtml, h } from '../src/hast'
 import { ExpressiveCodeLine } from '../src/common/line'
 import { renderLineToAst, splitLineAtAnnotationBoundaries } from '../src/internal/render-line'
-import { codeLineClass } from '../src/common/style-settings'
+import { codeBlockLineClass, inlineCodeLineClass } from '../src/common/style-settings'
 import { AnnotationBaseOptions, AnnotationRenderOptions, ExpressiveCodeAnnotation } from '../src/common/annotation'
 import { ExpressiveCodeBlock } from '../src/common/block'
 import { ResolvedExpressiveCodeEngineConfig } from '../src/common/engine'
@@ -176,22 +176,22 @@ describe('renderLineToAst()', () => {
 		test('Line starting with a class annotation', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['Wow'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code"><0>Wow</0>, I am rendered!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code"><0>Wow</0>, I am rendered!</div></div>`)
 		})
 		test('Line starting with a functional annotation', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['Wow'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code"><0>Wow</0>, I am rendered!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code"><0>Wow</0>, I am rendered!</div></div>`)
 		})
 		test('Line ending with a class annotation', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['rendered!'], useFunctionalSyntax: true })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, I am <0>rendered!</0></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, I am <0>rendered!</0></div></div>`)
 		})
 		test('Line ending with a functional annotation', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['rendered!'], useFunctionalSyntax: true })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, I am <0>rendered!</0></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, I am <0>rendered!</0></div></div>`)
 		})
 	})
 
@@ -199,24 +199,24 @@ describe('renderLineToAst()', () => {
 		test('Single line-level class annotation', () => {
 			const line = new ExpressiveCodeLine(testText)
 			line.addAnnotation(new ClassNameAnnotation({ addClass: 'del' }))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del"><div class="code">Wow, I am rendered!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del"><div class="code">Wow, I am rendered!</div></div>`)
 		})
 		test('Single line-level functional annotation', () => {
 			const line = new ExpressiveCodeLine(testText)
 			line.addAnnotation(classNameAnnotation('del'))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del"><div class="code">Wow, I am rendered!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del"><div class="code">Wow, I am rendered!</div></div>`)
 		})
 		test('Multiple line-level class annotations', () => {
 			const line = new ExpressiveCodeLine(testText)
 			line.addAnnotation(new ClassNameAnnotation({ addClass: 'del' }))
 			line.addAnnotation(new ClassNameAnnotation({ addClass: 'mark' }))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del mark"><div class="code">Wow, I am rendered!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del mark"><div class="code">Wow, I am rendered!</div></div>`)
 		})
 		test('Multiple line-level functional annotations', () => {
 			const line = new ExpressiveCodeLine(testText)
 			line.addAnnotation(classNameAnnotation('del'))
 			line.addAnnotation(classNameAnnotation('mark'))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del mark"><div class="code">Wow, I am rendered!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del mark"><div class="code">Wow, I am rendered!</div></div>`)
 		})
 	})
 
@@ -226,21 +226,21 @@ describe('renderLineToAst()', () => {
 			line.addAnnotation(new ClassNameAnnotation({ addClass: 'del' }))
 			annotateMatchingTextParts({ line, partsToAnnotate: ['rendered', 'I am rendered!'] })
 			line.addAnnotation(new ClassNameAnnotation({ addClass: 'mark' }))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del mark"><div class="code">Wow, <2>I am <1>rendered</1>!</2></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del mark"><div class="code">Wow, <2>I am <1>rendered</1>!</2></div></div>`)
 		})
 		test('With functional annotations', () => {
 			const line = new ExpressiveCodeLine(testText)
 			line.addAnnotation(classNameAnnotation('del'))
 			annotateMatchingTextParts({ line, partsToAnnotate: ['rendered', 'I am rendered!'], useFunctionalSyntax: true })
 			line.addAnnotation(classNameAnnotation('mark'))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del mark"><div class="code">Wow, <2>I am <1>rendered</1>!</2></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del mark"><div class="code">Wow, <2>I am <1>rendered</1>!</2></div></div>`)
 		})
 		test('With both combined', () => {
 			const line = new ExpressiveCodeLine(testText)
 			line.addAnnotation(new ClassNameAnnotation({ addClass: 'del' }))
 			annotateMatchingTextParts({ line, partsToAnnotate: ['rendered', 'I am rendered!'], useFunctionalSyntax: true })
 			line.addAnnotation(classNameAnnotation('mark'))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del mark"><div class="code">Wow, <2>I am <1>rendered</1>!</2></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del mark"><div class="code">Wow, <2>I am <1>rendered</1>!</2></div></div>`)
 		})
 	})
 
@@ -248,7 +248,7 @@ describe('renderLineToAst()', () => {
 		test('Line starting and ending with an annotation', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['Wow', 'rendered!'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code"><0>Wow</0>, I am <1>rendered!</1></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code"><0>Wow</0>, I am <1>rendered!</1></div></div>`)
 		})
 	})
 
@@ -256,39 +256,39 @@ describe('renderLineToAst()', () => {
 		test('Two annotations with matching boundaries', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['rendered', 'rendered'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, I am <1><0>rendered</0></1>!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, I am <1><0>rendered</0></1>!</div></div>`)
 		})
 		test('Two annotations where the second is fully contained in the first', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['I am rendered', 'am'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <0>I </0><1><0>am</0></1><0> rendered</0>!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <0>I </0><1><0>am</0></1><0> rendered</0>!</div></div>`)
 		})
 		test('Two annotations where the first is fully contained in the second', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['am', 'I am rendered'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <1>I <0>am</0> rendered</1>!</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <1>I <0>am</0> rendered</1>!</div></div>`)
 		})
 		test('Two partially intersecting annotations', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['Wow, I am', 'I am rendered!'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code"><0>Wow, </0><1><0>I am</0> rendered!</1></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code"><0>Wow, </0><1><0>I am</0> rendered!</1></div></div>`)
 		})
 		test('Three annotations where part indices must move after merging', () => {
 			const line = new ExpressiveCodeLine(testText)
 			annotateMatchingTextParts({ line, partsToAnnotate: ['am', 'I am rendered', '!'] })
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <1>I <0>am</0> rendered</1><2>!</2></div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <1>I <0>am</0> rendered</1><2>!</2></div></div>`)
 		})
 	})
 
 	describe('Ensures that empty lines are visible', () => {
 		test('Empty lines are rendered with a line break inside', () => {
 			const line = new ExpressiveCodeLine('')
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">\n</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">\n</div></div>`)
 		})
 		test('Empty lines also work with line-level annotations', () => {
 			const line = new ExpressiveCodeLine('')
 			line.addAnnotation(new ClassNameAnnotation({ addClass: 'del' }))
-			expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass} del"><div class="code">\n</div></div>`)
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass} del"><div class="code">\n</div></div>`)
 		})
 	})
 
@@ -298,13 +298,13 @@ describe('renderLineToAst()', () => {
 				const line = new ExpressiveCodeLine(testText)
 				annotateMatchingTextParts({ line, partsToAnnotate: ['I am rendered'], renderPhase: 'latest' })
 				annotateMatchingTextParts({ line, partsToAnnotate: ['am'] })
-				expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
+				expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
 			})
 			test('Annotation #0 with phase "normal" is rendered after #1 with "earlier"', () => {
 				const line = new ExpressiveCodeLine(testText)
 				annotateMatchingTextParts({ line, partsToAnnotate: ['I am rendered'] })
 				annotateMatchingTextParts({ line, partsToAnnotate: ['am'], renderPhase: 'earlier' })
-				expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
+				expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
 			})
 		})
 		describe('With functional annotations', () => {
@@ -312,13 +312,13 @@ describe('renderLineToAst()', () => {
 				const line = new ExpressiveCodeLine(testText)
 				annotateMatchingTextParts({ line, partsToAnnotate: ['I am rendered'], renderPhase: 'latest', useFunctionalSyntax: true })
 				annotateMatchingTextParts({ line, partsToAnnotate: ['am'], useFunctionalSyntax: true })
-				expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
+				expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
 			})
 			test('Annotation #0 with phase "normal" is rendered after #1 with "earlier"', () => {
 				const line = new ExpressiveCodeLine(testText)
 				annotateMatchingTextParts({ line, partsToAnnotate: ['I am rendered'], useFunctionalSyntax: true })
 				annotateMatchingTextParts({ line, partsToAnnotate: ['am'], renderPhase: 'earlier', useFunctionalSyntax: true })
-				expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
+				expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
 			})
 		})
 		describe('With a mix of class and functional annotations', () => {
@@ -326,14 +326,25 @@ describe('renderLineToAst()', () => {
 				const line = new ExpressiveCodeLine(testText)
 				annotateMatchingTextParts({ line, partsToAnnotate: ['I am rendered'], renderPhase: 'latest' })
 				annotateMatchingTextParts({ line, partsToAnnotate: ['am'], useFunctionalSyntax: true })
-				expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
+				expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
 			})
 			test('Annotation #0 with phase "normal" is rendered after #1 with "earlier"', () => {
 				const line = new ExpressiveCodeLine(testText)
 				annotateMatchingTextParts({ line, partsToAnnotate: ['I am rendered'] })
 				annotateMatchingTextParts({ line, partsToAnnotate: ['am'], renderPhase: 'earlier', useFunctionalSyntax: true })
-				expect(renderLineToHtml(line)).toEqual(`<div class="${codeLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
+				expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">Wow, <0>I <1>am</1> rendered</0>!</div></div>`)
 			})
+		})
+	})
+
+	describe('Ensures appropriate structure based on code block type', () => {
+		test('code block', () => {
+			const line = new ExpressiveCodeLine('')
+			expect(renderLineToHtml(line)).toEqual(`<div class="${codeBlockLineClass}"><div class="code">\n</div></div>`)
+		})
+		test('inline code', () => {
+			const line = new ExpressiveCodeLine('')
+			expect(renderLineToHtml(line, { type: 'inline' })).toEqual(`<span class="${inlineCodeLineClass}"><span class="code-inline">\n</span></span>`)
 		})
 	})
 })
@@ -367,16 +378,16 @@ function expectPartsToMatchAnnotationText(line: ExpressiveCodeLine, actual: Retu
 	})
 }
 
-function renderLineToHtml(line: ExpressiveCodeLine) {
-	return toHtml(renderLineToAstWrapper(line))
+function renderLineToHtml(line: ExpressiveCodeLine, codeBlock = {}) {
+	return toHtml(renderLineToAstWrapper(line, codeBlock))
 }
 
-function renderLineToAstWrapper(line: ExpressiveCodeLine) {
+function renderLineToAstWrapper(line: ExpressiveCodeLine, codeBlock = {}) {
 	return renderLineToAst({
 		line,
 		lineIndex: 0,
 		gutterElements: [],
-		codeBlock: {} as ExpressiveCodeBlock,
+		codeBlock: codeBlock as ExpressiveCodeBlock,
 		groupContents: [],
 		locale: 'en-US',
 		config: {} as ResolvedExpressiveCodeEngineConfig,

--- a/packages/@expressive-code/core/test/utils.ts
+++ b/packages/@expressive-code/core/test/utils.ts
@@ -147,10 +147,27 @@ export const defaultBlockOptions = {
 	meta: 'test',
 }
 
-export const lineCodeHtml = ['<div class="code">Example code...</div>', '<div class="code">...with two lines!</div>']
+export const defaultInlineCodeOptions: ExpressiveCodeBlockOptions = {
+	code: `console.log('hello world')`,
+	language: 'js',
+	type: 'inline',
+}
 
-export function toSanitizedHtml(ast: Parents, options?: { extraAttributes?: PropertyDefinition[] | undefined }) {
-	const html = toHtml(sanitize(ast, { attributes: { '*': ['test', 'edited', ['className', /^code$/], ...(options?.extraAttributes ?? [])], a: ['href'] }, tagNames: null }))
+export const lineCodeHtml = ['<div class="code">Example code...</div>', '<div class="code">...with two lines!</div>']
+export const inlineCodeHtml = '<span class="code-inline">console.log(\'hello world\')</span>'
+
+const sanitizedLineClassNames = /^code|code-inline$/
+const sanitizedClassNames = /^code|code-inline|ec-container-block|ec-container-inline|ec-container-mixed$/
+export function toSanitizedHtml(ast: Parents, options?: { extraAttributes?: PropertyDefinition[] | undefined; includeContainerClasses?: boolean | undefined }) {
+	const html = toHtml(
+		sanitize(ast, {
+			attributes: {
+				'*': ['test', 'edited', ['className', options?.includeContainerClasses ? sanitizedClassNames : sanitizedLineClassNames], ...(options?.extraAttributes ?? [])],
+				a: ['href'],
+			},
+			tagNames: null,
+		})
+	)
 	return html.replace(/ class=""/g, '')
 }
 

--- a/packages/@expressive-code/plugin-collapsible-sections/README.md
+++ b/packages/@expressive-code/plugin-collapsible-sections/README.md
@@ -11,3 +11,7 @@ It allows code sections to be marked as collapsed. The lines in collapsed sectio
 ## Installation
 
 See the [installation instructions](https://expressive-code.com/plugins/collapsible-sections/#installation) for this plugin to learn how to install it on your site.
+
+## Code Block Support
+
+Does not support `inline` code blocks.

--- a/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
+++ b/packages/@expressive-code/plugin-collapsible-sections/src/styles.ts
@@ -1,4 +1,4 @@
-import { PluginStyleSettings, ResolverContext, codeLineClass, createInlineSvgUrl, setAlpha } from '@expressive-code/core'
+import { PluginStyleSettings, ResolverContext, codeBlockLineClass, createInlineSvgUrl, setAlpha } from '@expressive-code/core'
 
 export const collapsibleSectionClass = 'ec-section'
 
@@ -211,7 +211,7 @@ export function getCollapsibleSectionsBaseStyles({ cssVar }: ResolverContext) {
 					margin-left: 1em;
 				}
 
-				.${codeLineClass} .code {
+				.${codeBlockLineClass} .code {
 					padding-block: ${cssVar('collapsibleSections.closedPaddingBlock')};
 					text-indent: 0;
 				}

--- a/packages/@expressive-code/plugin-frames/README.md
+++ b/packages/@expressive-code/plugin-frames/README.md
@@ -11,3 +11,7 @@ It renders a window frame around every code block. Depending on the code's langu
 ## Installation (not required)
 
 No installation is required. This package is **installed by default** by our higher-level packages.
+
+## Code Block Support
+
+Does not support `inline` code blocks.

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -1,5 +1,5 @@
 import type { ResolverContext } from '@expressive-code/core'
-import { PluginStyleSettings, codeLineClass, createInlineSvgUrl, multiplyAlpha, onBackground, setLuminance } from '@expressive-code/core'
+import { PluginStyleSettings, codeBlockLineClass, createInlineSvgUrl, multiplyAlpha, onBackground, setLuminance } from '@expressive-code/core'
 import type { PluginFramesOptions } from '.'
 
 export interface FramesStyleSettings {
@@ -562,7 +562,7 @@ export function getFramesBaseStyles({ cssVar }: ResolverContext, options: Plugin
 	}
 	
 	/* Increase end padding of the first line for the copy button */
-	:nth-child(1 of .${codeLineClass}) .code {
+	:nth-child(1 of .${codeBlockLineClass}) .code {
 		padding-inline-end: calc(2rem + ${cssVar('codePaddingInline')});
 	}`
 

--- a/packages/@expressive-code/plugin-line-numbers/README.md
+++ b/packages/@expressive-code/plugin-line-numbers/README.md
@@ -1,0 +1,17 @@
+# @expressive-code/plugin-line-numbers
+
+An optional plugin for [Expressive Code](https://expressive-code.com/), an engine for presenting source code on the web.
+
+It allows you to display line numbers in your code blocks. The line numbers are displayed in the gutter to the left of the code.
+
+## Documentation
+
+[Read this plugin's documentation](https://expressive-code.com/plugins/line-numbers/) on the Expressive Code website to learn more about its features.
+
+## Installation
+
+See the [installation instructions](https://expressive-code.com/plugins/line-numbers/#installation) for this plugin to learn how to install it on your site.
+
+## Code Block Support
+
+Does not support `inline` code blocks.

--- a/packages/@expressive-code/plugin-shiki/README.md
+++ b/packages/@expressive-code/plugin-shiki/README.md
@@ -11,3 +11,7 @@ It performs syntax highlighting of your code blocks using Shiki, which uses the 
 ## Installation (not required)
 
 No installation is required. This package is **installed by default** by our higher-level packages.
+
+## Code Block Support
+
+Supports both `block` and `inline` code blocks.

--- a/packages/@expressive-code/plugin-shiki/src/index.ts
+++ b/packages/@expressive-code/plugin-shiki/src/index.ts
@@ -105,6 +105,7 @@ export function pluginShiki(options: PluginShikiOptions = {}): ExpressiveCodePlu
 
 	return {
 		name: 'Shiki',
+		supportedCodeBlockTypes: ['block', 'inline'],
 		hooks: {
 			performSyntaxAnalysis: async ({ codeBlock, styleVariants, config: { logger } }) => {
 				const codeLines = codeBlock.getLines()

--- a/packages/@expressive-code/plugin-text-markers/README.md
+++ b/packages/@expressive-code/plugin-text-markers/README.md
@@ -13,3 +13,7 @@ It also ensures accessible color contrast of the marked code, automatically twea
 ## Installation (not required)
 
 No installation is required. This package is **installed by default** by our higher-level packages.
+
+## Code Block Support
+
+Does not support `inline` code blocks.

--- a/packages/@expressive-code/plugin-text-markers/src/styles.ts
+++ b/packages/@expressive-code/plugin-text-markers/src/styles.ts
@@ -1,4 +1,4 @@
-import { PluginStyleSettings, codeLineClass, toHexColor, StyleSettingPath, ResolverContext, StyleResolverFn } from '@expressive-code/core'
+import { PluginStyleSettings, codeBlockLineClass, toHexColor, StyleSettingPath, ResolverContext, StyleResolverFn } from '@expressive-code/core'
 import { MarkerType } from './marker-types'
 
 export interface TextMarkersStyleSettings {
@@ -239,7 +239,7 @@ export const textMarkersStyleSettings = new PluginStyleSettings({
 
 export function getTextMarkersBaseStyles({ cssVar }: ResolverContext) {
 	const result = `
-		.${codeLineClass} {
+		.${codeBlockLineClass} {
 			/* Support line-level mark/ins/del */
 			&.mark {
 				--tmLineBgCol: ${cssVar('textMarkers.markBackground')};

--- a/packages/rehype-expressive-code/README.md
+++ b/packages/rehype-expressive-code/README.md
@@ -13,3 +13,11 @@ When you're using markdown / MDX and want to improve the design and functionalit
 ## Installation
 
 Read the [installation instructions](https://expressive-code.com/installation/) to learn how to install Expressive Code.
+
+## Detecting code block type and language
+
+When a code block is detected by Expressive Code, the `<code>` element will be wrapped in a `<pre>` (for `block` code) or `<span>` (for `inline` code) element that will contain the following data attributes which can be helpful for conditional
+handling in downstream processing (e.g., `CSS`, `react-markdown`, etc.):
+
+- `data-language`: syntax highlighting language (e.g., `js`)
+- `data-ec-type`: `block` or `inline`

--- a/packages/rehype-expressive-code/src/utils.ts
+++ b/packages/rehype-expressive-code/src/utils.ts
@@ -1,24 +1,82 @@
-import type { Element } from 'expressive-code/hast'
+import type { Element, Parents } from 'expressive-code/hast'
 import type { MdxJsxFlowElementHast, MdxJsxAttribute } from 'mdast-util-mdx-jsx'
 import { getClassNames } from 'expressive-code/hast'
+import type { ExpressiveCodeBlockType } from 'expressive-code'
+import type { RehypeExpressiveCodeOptions } from './index'
 
 export type CodeBlockInfo = NonNullable<ReturnType<typeof getCodeBlockInfo>>
+export type InlineCodeHandler = 'trailing-curly-colon'
+export type RehypeExpressiveCodeBlockHandler = (
+	node: Element,
+	parent: Parents
+) =>
+	| {
+			type: ExpressiveCodeBlockType
+			node: Element
+			text: string
+			lang: string
+			meta?: string | undefined
+	  }
+	| undefined
 
-export function getCodeBlockInfo(pre: Element) {
-	if (pre.tagName !== 'pre' || pre.children.length !== 1) return
+const getPreCodeBlockInfo: RehypeExpressiveCodeBlockHandler = (pre: Element) => {
 	const code = pre.children[0]
-	if (code.type !== 'element' || code.tagName !== 'code') return
+	if (!code || code.type !== 'element' || code.tagName !== 'code' || !code.properties) return
 	const text = code.children[0]
 	if (text.type !== 'text') return
 	const langClass = getClassNames(code).find((c) => c.startsWith('language-')) ?? ''
 	const lang = langClass.replace('language-', '')
 	const meta = (code.data?.meta ?? code.properties?.metastring ?? '') as string
 	return {
-		pre,
-		code,
-		lang,
+		type: 'block',
+		node: pre,
 		text: text.value,
+		lang,
 		meta,
+	}
+}
+
+export const InlineCodeHandlers: Record<InlineCodeHandler, RehypeExpressiveCodeBlockHandler> = {
+	'trailing-curly-colon': (code, parent) => {
+		if (parent.type !== 'element' || parent.tagName === 'pre') return
+		const text = code.children[0]
+		if (text.type !== 'text') return
+		const value = text.value
+		if (!value) return
+		// find a lang tag. if escaped (immediately preceded by an odd number of backslashes),
+		// replace the last backslash with an empty string, unescape the remaining pairs and
+		// skip processing. If not escaped, unescape any backslash pairs and process.
+		const match = value.match(/(\\*)\{:([\w-]+)\}$/)
+		if (!match) return
+		const [fullMatch, backslashes, lang] = match
+		if (backslashes.length % 2 === 1) {
+			// drop the last backslash, then unescape pairs
+			const bs = backslashes.slice(0, -1).replace(/\\\\/g, '\\')
+			text.value = value.slice(0, match.index) + bs + fullMatch.slice(backslashes.length)
+			return
+		}
+
+		// unescape any backslash pairs
+		const bs = backslashes.length ? backslashes.replace(/\\\\/g, '\\') : ''
+		text.value = value.slice(0, match.index) + bs
+		return {
+			type: 'inline',
+			node: code,
+			text: text.value,
+			lang: lang,
+		}
+	},
+}
+
+export function getCodeBlockInfo(inline: RehypeExpressiveCodeOptions['inline'], node: Element, parent: Parents) {
+	if (node.children.length !== 1) return
+	if (node.tagName === 'pre') return getPreCodeBlockInfo(node, parent)
+	if (node.tagName === 'code' && inline) {
+		const handler = InlineCodeHandlers[inline]
+		if (!handler) {
+			throw new Error(`Unsupported 'inline' value: [${inline}]`)
+		}
+		return handler(node, parent)
 	}
 }
 

--- a/packages/rehype-expressive-code/test/utils.ts
+++ b/packages/rehype-expressive-code/test/utils.ts
@@ -4,7 +4,12 @@ export const sampleCodeMarkdown = `
 // test.js
 const a = 1
 \`\`\`
+
+# Inline
+\`const getStringLength = (str) => str.length;{:js}\`
 `
+
+export const sampleCodeMarkdownInlineDisabledCodeContents = ['const getStringLength = \\(str\\) => str.length;{:js}']
 
 export const buildSampleCodeHtmlRegExp = ({ title, codeContents }: { title: string; codeContents: string[] }) =>
 	new RegExp(
@@ -28,5 +33,48 @@ export const buildSampleCodeHtmlRegExp = ({ title, codeContents }: { title: stri
 			'(?<copyButton><div class="copy">.*?</div>)?',
 			'</figure>',
 			'</div>',
+		].join('\\s*')
+	)
+
+export const buildSampleCodeHtmlInlineRegExp = ({
+	title,
+	codeContents,
+	enabled = false,
+	inlineCodeContents = sampleCodeMarkdownInlineDisabledCodeContents,
+}: {
+	title: string
+	codeContents: string[]
+	enabled?: boolean | undefined
+	inlineCodeContents?: string[] | undefined
+}) =>
+	new RegExp(
+		[
+			// The heading should have been transformed to an h1
+			'<h1(?:| .*?)>[^<]*?</h1>',
+			// The code block group should have been wrapped into an Expressive Code div
+			'<div class="expressive-code(| .*?)">',
+			// Expect one style element or link to an external stylesheet
+			// and capture it in the "styles" capture group
+			'(?<styles><style>[\\s\\S]*?</style>|<link rel="stylesheet" href="[^"]*?/ec\\..*?\\.css"(\\s*/)?>)',
+			// Allow 0-n script modules and capture them in the "scripts" capture group
+			'(?<scripts><script type="module"(?: src="[^"]*?/ec\\..*?\\.js")?>[\\s\\S]*?</script>)*',
+			// Start of the code block
+			'<figure(?:| .*?)>',
+			'<figcaption(?:| .*?)>.*?' + title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '.*?</figcaption>',
+			'<pre(?:| .*?)><code(?:| .*?)>',
+			...codeContents,
+			'</code></pre>',
+			// Allow an optional copy button
+			'(?<copyButton><div class="copy">.*?</div>)?',
+			'</figure>',
+			'</div>',
+			'<h1(?:| .*?)>[^<]*?</h1>',
+			...[
+				'<p>',
+				...(enabled
+					? ['<span class="expressive-code(| .*?)">', '<span(?:| .*?)><code(?:| .*?)>', ...inlineCodeContents, '</code></span>', '</span>']
+					: ['<code>', ...inlineCodeContents, '</code>']),
+				'</p>',
+			],
 		].join('\\s*')
 	)


### PR DESCRIPTION
Adds support for processing inline code

Apologies in advance for the long description but providing for two reasons:

1. There hasn't been a design discussion around how to implement `inline code` processing other than the very high-level comments in #250 so wanted to provide context on why this approach was taken to hopefully pre-emptively address as many questions as possible to accelerate approval/merge 😃
2. While this PR achieves the design goals stated below, I believe there is a better way to approach this but it would mean some additional generated HTML changes, albeit for the better IMHO, so I wanted to provide full context.  See [Bottom line](#bottom-line) for details.

## TL;DR

| Version | Markdown | Rendered |
| -------- | ------------ | -------------- |
| v0.41.2 | Inline code example `console.log('Hello!')` | ![image](https://github.com/user-attachments/assets/4ad1c1b1-e35b-4817-9870-b18104595c77) |
| This PR | Inline code example `console.log('Hello!'){:js}` | ![image](https://github.com/user-attachments/assets/05b43f9a-a44f-4975-82bc-a5bc1075692c) |

## Design Goals
1. 100% backwards compatible with `v0.41.2` - Achieved with two exceptions specific to generated HTML output, neither of which should cause any functional backwards compatibility issues UNTIL the user opts-in to `inline code` processing and even then, they may or may not cause issues (see [Styling](#styling) for more information):
    1. Generated Styles
        1. [.expressive-code CSS defaults](https://github.com/expressive-code/expressive-code/compare/main...techfg:expressive-code:feat/support-inline-code-blocks?expand=1#diff-5148f4c69fd8ab82378f37e23db55141736aaf7c033b52341162a69241b10c42R235) - Previously would be directly under `.expressive-code` but is now wrapped in a `.ec-container-block` class
        2. [InlineStyleAnnotation CSS Selector](https://github.com/techfg/expressive-code/blob/eb5792dc041cf1042a179175d55ae8b449cfa800/packages/%40expressive-code/core/src/internal/core-styles.ts#L397) - Need to account for new `.ec-line-inline` class
        2. [`.ec-container-inline` CSS class](https://github.com/expressive-code/expressive-code/compare/main...techfg:expressive-code:feat/support-inline-code-blocks?expand=1#diff-5148f4c69fd8ab82378f37e23db55141736aaf7c033b52341162a69241b10c42R254) - New class included in generated styles that did not previously exist
    2. Generated HTML - [`ec-type`](https://github.com/techfg/expressive-code/blob/eb5792dc041cf1042a179175d55ae8b449cfa800/packages/%40expressive-code/core/src/internal/render-block.ts#L151) attributed added to `pre` element
2. Ability for __any__ plugin to opt-in to handling `inline code` - Achieved
3. All existing tests should pass without modification - Achieved with two exceptions both specific to the Generated Styles and HTML mentioned above:
    1. https://github.com/expressive-code/expressive-code/compare/main...techfg:expressive-code:feat/support-inline-code-blocks?expand=1#diff-0758693987f5646a7fbb2a2ad18f440820778445294e9138b5c2277ffa69211bR151
    2. https://github.com/expressive-code/expressive-code/compare/main...techfg:expressive-code:feat/support-inline-code-blocks?expand=1#diff-0758693987f5646a7fbb2a2ad18f440820778445294e9138b5c2277ffa69211bR218
4. Inline code language detection should be extensible to support multiple formats - Achieved via [InlineCodeHandler](https://github.com/techfg/expressive-code/blob/eb5792dc041cf1042a179175d55ae8b449cfa800/packages/rehype-expressive-code/src/utils.ts#L39) with a credit to [rehype-shiki](https://github.com/shikijs/shiki/blob/main/packages/rehype/src/handlers.ts#L17) for the inspiration.

### Functional Implementation

Four (4) different approaches were considered:

1. Call the existing hook signatures and rely on the hook to conditionally determine if it supports `inline`.
    - Pros: Minimizes the amount of code changes required
    - Cons: Not 100% backwards compatible as while the EC plugins could be adjusted as part of this PR to opt-in/out of inline, any EC plugin out in the wild could potentially break until it's updated to explicitly decide on supporting `inline`
2. Add a `<hookname>Inline` set of hooks
    - Pros:
        - Explicit entry point for plugins to handle `inline` blocks
        - Allows for discrete Code Block classes that would be passed (e.g., `ExpressiveCodeBlock`, `ExpressiveInlineCodeBlock`) and Hook function signatures to differentiate parameters (e.g., `inline` does not support gutters so `addGutterElement` wouldn't be defined on it's hook properties)
        - 100% backwards compatible
    - Cons: Doubles the number of EC hooks and moving forward, if new "Code Block" types are added (unlikely) or additional hooks added (possible), would further increase the number of hooks
3. Add a `supportedCodeBlockTypes` plugin option that returns an array of which types of code blocks that the plugin wants its hooks called for with the default being `block` only if `supportedCodeBlockTypes` is not defined by the plugin
    - Pros:
        - Minimizes the amount of code changes required
        - 100% backwards compatible
    - Cons:
        - Adds one property to hook definition API
        - Doesn't provide discrete method of handling Code Blocks types and/or hooks as it requires conditional logic to handle `inline` and `codeblock` differently within the existing hooks
4. Add a plugin hook registration API - similar to Option 3 but extends the concept to do a full registration of all hooks and for which types a plugin supports
    - Pros:
        - Explicit approach for plugins to inform EC where it wants to be involved in the processing and specifically which hooks and for which types (e.g., could support `inline` on only a subset of hooks)
        - The "registration api" is mentioned in https://github.com/expressive-code/expressive-code/pull/335#issuecomment-2849883838 regarding styles and having an explicit way to register styles could help eliminate side effects that are currently in-play and prohibit EC and EC's various packages from being marked `sideEffects: false` in package.json which leads to unnecessary increase to bundle size in some situations.  If a style registration API were to be added, it could be coupled with a hook registration API.
    - Cons:
        - Changes the current hook API approach (although this potentially could be for the better)
        - Requires modifications to all existing plugins to call the registration entry point (default functionality could still be invoked if a plugin doesn't register and the old approach could be deprecated)

**Decision**: Option 2 is the most robust and type-safe approach, however it requires much more code to be written to accomidate.  Additionally, it's likely an over-enginered approach since there are only a few differences between `inline` and `block` in terms of `ExpressiveCodeBlock` handling. For these reasons, Option 3 was chosen since it is least invasive and most straightforward.

### Styling

Unlike the functional implementation, accounting for styles was not a straightforward solution.  There were two main reasons for this:

1. The styling system is in `v0.41.2` is written to assume there are only `code blocks` within `.expressive-code` so styles are loosely applied in certain cases.  For example, any `.ec-line`, even if it doesn't live within a `pre` is styled by [plugin-frames](https://github.com/techfg/expressive-code/blob/eb5792dc041cf1042a179175d55ae8b449cfa800/packages/%40expressive-code/plugin-frames/src/styles.ts#L565).  Similarly, `expressive-code` itself styles any [.ec-line](https://github.com/techfg/expressive-code/blob/eb5792dc041cf1042a179175d55ae8b449cfa800/packages/%40expressive-code/core/src/internal/core-styles.ts#L327) that lives anywhere inside of `.expressive-code`.
2. [render](https://github.com/techfg/expressive-code/blob/eb5792dc041cf1042a179175d55ae8b449cfa800/packages/%40expressive-code/core/src/common/engine.ts#L307) supports multiple `ExpressiveCodeBlock` instances which may now contain a mixture of `inline` and `block` so there needs to be a way to target styles specific to the [ExpressiveCodeBlockType](https://github.com/techfg/expressive-code/blob/eb5792dc041cf1042a179175d55ae8b449cfa800/packages/%40expressive-code/core/src/common/block.ts#L6) for the given code block.

Given the above, the approach taken had to ensure that it did not use some of the existing classes, like `.ec-line` to avoid styling issues when `inline code` is processed.

To achieve this, a couple of minor adjustments to generated styles and HTML were required as mentioned in [Design Goals](#design-goals).  The current approach is as follows with the changes between `v0.41.2` and this PR highlighted:

#### Single `code block` rendered regardless of `inline` configuration:
```diff html
- <div class="expressive-code">
+ <div class="expressive-code ec-container-block">
    ....
-    <pre data-language="js">
+    <pre data-language="js" data-ec-type="block">
        <code>
            <div class="ec-line">
                <div class="code">...</div>
            </div>
            ....
        </code>
    </pre>
</div>
```

#### Multiple `code blocks` rendered regardless of `inline` configuration:
```diff html
- <div class="expressive-code">
+ <div class="expressive-code ec-container-block">
    ....
-    <pre data-language="js">
+    <pre data-language="js" data-ec-type="block">
        <code>
            <div class="ec-line">
                <div class="code">...</div>
            </div>
            ....
        </code>
-    <pre data-language="js">
+    <pre data-language="js" data-ec-type="block">
        <code>
            <div class="ec-line">
                <div class="code">...</div>
            </div>
            ....
        </code>
    </pre>
</div>
```

The structure above is the same for `inline code` (single or multiple) when `render` is called with only `inline` block(s) with the only differences being `span` instead of `div` and the classes/attributes being `inline` variants.  

#### Single `inline code` rendered with `inline` enabled
```html
<span class="expressive-code ec-container-inline">
    <span data-language="js" data-ec-type="inline">
        <code>
            <span class="ec-line-inline">
                <span class="code-inline">...</span>
            </span>
            ...
        </code>
    </span>
</span>
```

#### Multiple `inline code` rendered with `inline` enabled
```html
<span class="expressive-code ec-container-inline">
    <span data-language="js" data-ec-type="inline">
        <code>
            <span class="ec-line-inline">
                <span class="code-inline">...</span>
            </span>
            ...
        </code>
    </span>
    <span data-language="js" data-ec-type="inline">
        <code>
            <span class="ec-line-inline">
                <span class="code-inline">...</span>
            </span>
            ...
        </code>
    </span>    
</span>
```

When a mixture of block types is passed to render, the structure with this PR is as follows:

```diff html
- <div class="expressive-code">
+ <div class="expressive-code ec-container-mixed">
+    <div class="ec-container-block">
        ...
-       <pre data-language="js">
+       <pre data-language="js" data-ec-type="block">
            <code>
                <div class="ec-line">
                    <div class="code">...</div>
                </div>
                ...
            </code>
         </pre>
    </div>
    <span class="ec-container-inline">
        <span data-language="js" data-ec-type="inline">
            <code>
                <span class="ec-line-inline">
                    <span class="code-inline">...</span>
                </span>
                ...
            </code>
        </span>
    </span>
</div>
```

## Bottom Line

While the existing PR achieves the desired outcome with minimal changes to generated styles and HTML, I believe that a better approach would be to change the generated HTML to structure each individual `ExpressiveCodeBlock` in its own container within the outer `.expressive-code` wrapper.  Doing so would provide the following benefits:

1. The structure of the HTML would be 100% identical regardless of how many `ExpressCodeBlocks` are rendered and what their `ExpressCodeBlockType` is
2. EC and all EC plugins would have an easier way of targeting style differences between `inline` and `block` by targeting classes and/or data attributes instead of tag names
3. "Common" elements between `block` and `inline` could use the same classes (e.g., `ec-line` instead of `ec-line` & `ec-line-inline`)

This approach, in some situations and depending on styling could introduce a breaking change.  With that said, EC and it's stock plugins would all be updated and versioned to handle in a release so it really comes down to non-EC core plugins and any user specified CSS styling that is applied.  The user based styling would be easy enough to account for by the users as they upgrade EC.  Looking at the [community plugins](), most define `peerDependencies` as `^0.#.#` (e.g., [color chips](https://github.com/delucis/expressive-code-color-chips/blob/main/packages/expressive-code-color-chips/package.json#L38)) and because of the zero-based semver of EC, would generate a peer deps warning since they don't support even the current version of EC unless they are `^0.41.2`.  There is one exception to this with [twoslash](https://github.com/MatthiesenXYZ/EC-Plugins/blob/main/packages/twoslash/package.json#L56) which defines as `>=0.40.0` so it would not warn on peer deps.  In short, the plugin ecosystem would need to be updated to account for the change in structure but most of the plugins are protected against a breaking change due to `^0.#.#` peer deps definition so users would be warned upon upgrading EC that plugins won't support the latest EC version yet.

Suggested HTML structure:

### Multiple `code blocks`
```html
<div class="expressive-code">
    <div class="ec-container-block" data-language="js" data-ec-type="block">
        ...
        <pre>
            <code>
                <div class="ec-line">
                    <div class="code">...</div>
                </div>
                ...
            </code>
        </pre>
    </div>
    <div class="ec-container-block" data-language="js" data-ec-type="block">
        ...
        <pre>
            <code>
                <div class="ec-line">
                    <div class="code">...</div>
                </div>
                ...
            </code>
        </pre>
    </div>
    ...    
</div>
```

### Multiple `inline code`
```html
<span class="expressive-code">
    <span class="ec-container-inline" data-language="js" data-ec-type="inline">
        <span>
            <code>
                <span class="ec-line">
                    <span class="code">...</span>
                </span>
                ...
            </code>
        </span>
    </span>
    <span class="ec-container-inline" data-language="js" data-ec-type="inline">
        <span>
            <code>
                <span class="ec-line">
                    <span class="code">...</span>
                </span>
                ...
            </code>
        </span>
    </span>
    ...    
</span>
```

### Multiple `inline code` & `code block`
```html
<div class="expressive-code">
    <div class="ec-container-block" data-language="js" data-ec-type="block">
        ...
        <pre>
            <code>
                <div class="ec-line">
                    <div class="code">...</div>
                </div>
                ...
            </code>
        </pre>
    </div>
    <span class="ec-container-inline" data-language="js" data-ec-type="inline">
        <span>
            <code>
                <span class="ec-line">
                    <span class="code">...</span>
                </span>
                ...
            </code>
        </span>
    </span>
    ...
</div>
```

Resolves #250