### PR TITLE
Bump allowed bundle size

### DIFF
--- a/packages/astro-expressive-code/test/integration.test.ts
+++ b/packages/astro-expressive-code/test/integration.test.ts
@@ -303,7 +303,7 @@ describe('Integration into Astro ^4.5.0 with Cloudflare adapter', () => {
 		).toHaveLength(0)
 	})
 
-	const allowedBundleSizeInMb = 2
+	const allowedBundleSizeInMb = 2.4
 	test(`Total bundle size does not exceed ${allowedBundleSizeInMb} MB`, () => {
 		const files = fixture?.readDirWithTypesRecursive('.') ?? []
 		const fileSizes = files


### PR DESCRIPTION
Fixes ecosystem CI test failure due to increased Astro bundle size (likely caused by Zod now being part of the bundle)