### PR TITLE
Update link to fullscreen plugin documentation

### DIFF
--- a/docs/src/content/docs/plugins/community-plugins.mdx
+++ b/docs/src/content/docs/plugins/community-plugins.mdx
@@ -31,7 +31,7 @@ The community-maintained plugins on this page extend Expressive Code to add new 
 			description: 'Separate code from its output within a codeblock.',
 		},
     {
-			href: 'https://github.com/frostybee/expressive-code-fullscreen',
+			href: 'https://frostybee.github.io/expressive-code-fullscreen',
 			title: 'expressive-code-fullscreen',
 			description: 'Add fullscreen viewing mode to your code blocks.',
 		}


### PR DESCRIPTION
This PR updates the link to the fullscreen plugin’s documentation website.