### PR TITLE
Add option to remove deleted text when copying

### DIFF
--- a/.changeset/old-planes-reply.md
+++ b/.changeset/old-planes-reply.md
@@ -1,0 +1,7 @@
+---
+'@expressive-code/plugin-frames': minor
+---
+
+Adds a new `removeDeletedTextWhenCopying` option to remove text marked as "deleted" when copying. This option is false by default for backwards-compatibility.
+
+If `removeDeletedTextWhenCopying` is true, any lines or segments of code that are marked as deleted using the `plugin-text-markers` plugin are not included when copied to the clipboard. This will also disallow the selection of said deleted lines or segments.

--- a/docs/src/content/docs/key-features/frames.mdx
+++ b/docs/src/content/docs/key-features/frames.mdx
@@ -206,6 +206,17 @@ If `true`, the "Copy to clipboard" button of terminal window frames will remove 
 
 This is useful to reduce the copied text to the actual commands users need to run, instead of also copying explanatory comments or instructions.
 
+#### removeDeletedTextWhenCopying
+
+<PropertySignature>
+- Type: `boolean`
+- Default: ``false``
+</PropertySignature>
+
+If `true`, the "Copy to clipboard" button of terminal window frames will remove text marked as deleted using the Text & Line Markers plugin.
+
+This is useful to reduce the copied text to the code that results after the marked text is deleted, instead of also copying the deleted portions.
+
 #### showCopyToClipboardButton
 
 <PropertySignature>

--- a/packages/@expressive-code/plugin-frames/src/styles.ts
+++ b/packages/@expressive-code/plugin-frames/src/styles.ts
@@ -566,11 +566,19 @@ export function getFramesBaseStyles({ cssVar }: ResolverContext, options: Plugin
 		padding-inline-end: calc(2rem + ${cssVar('codePaddingInline')});
 	}`
 
+	const removeDeletedTextStyles = `.ec-line.del, .ec-line del {
+	  /* Disallow selection of deleted text */
+		user-select: none;
+		-webkit-user-select: none;
+	}`
+
 	const styles = [
 		// Always add base frame styles
 		frameStyles,
 		// Add copy button styles if enabled
 		options.showCopyToClipboardButton ? copyButtonStyles : '',
+		// Add remove-deleted-text styles if enabled
+		options.removeDeletedTextWhenCopying ? removeDeletedTextStyles : '',
 	]
 
 	return styles.join('\n')


### PR DESCRIPTION
Fixes #314.

Adds a new `removeDeletedTextWhenCopying` option to remove text marked as "deleted" when copying. This option is false by default for backwards-compatibility.

If `removeDeletedTextWhenCopying` is true, any lines or segments of code that are marked as deleted using the `plugin-text-markers` plugin are not included when copied to the clipboard. This will also disallow the selection of said deleted lines or segments.