### PR TITLE
Add file icons plugin to community plugins page

### DIFF
--- a/docs/src/content/docs/plugins/community-plugins.mdx
+++ b/docs/src/content/docs/plugins/community-plugins.mdx
@@ -30,16 +30,20 @@ The community-maintained plugins on this page extend Expressive Code to add new 
 			title: '@fujocoded/expressive-code-output',
 			description: 'Separate code from its output within a codeblock.',
 		},
-    {
+		{
 			href: 'https://frostybee.github.io/expressive-code-fullscreen',
 			title: 'expressive-code-fullscreen',
 			description: 'Add fullscreen viewing mode to your code blocks.',
-		}
-    ,
-    {
+		},
+		{
 			href: 'https://frostybee.github.io/expressive-code-language-badge/',
 			title: 'expressive-code-language-badge',
 			description: 'Add a language badge to your code blocks.',
-		}
+		},
+		{
+			href: 'https://github.com/xt0rted/expressive-code-file-icons',
+			title: 'expressive-code-file-icons',
+			description: 'Add VS Code-style file icons to your code blocks.',
+		},
 	]}
 />


### PR DESCRIPTION
This adds the plugin mentioned in #257 to the community plugins page in docs.