### PR TITLE
Add community plugin: express-code-links

### DIFF
--- a/docs/src/content/docs/plugins/community-plugins.mdx
+++ b/docs/src/content/docs/plugins/community-plugins.mdx
@@ -11,11 +11,6 @@ The community-maintained plugins on this page extend Expressive Code to add new 
 <ShowcaseText
 	entries={[
 		{
-			href: 'https://github.com/towc/expressive-code-links#links',
-			title: 'expressive-code-links',
-			description: 'Add clickable links within your code blocks',
-		},
-		{
 			href: 'https://delucis.github.io/expressive-code-color-chips/',
 			title: 'expressive-code-color-chips',
 			description: 'Add color previews to your CSS code examples.',
@@ -49,6 +44,11 @@ The community-maintained plugins on this page extend Expressive Code to add new 
 			href: 'https://github.com/xt0rted/expressive-code-file-icons',
 			title: 'expressive-code-file-icons',
 			description: 'Add VS Code-style file icons to your code blocks.',
+		},
+		{
+			href: 'https://github.com/towc/expressive-code-links#links',
+			title: 'expressive-code-links',
+			description: 'Add clickable links within your code blocks',
 		},
 	]}
 />


### PR DESCRIPTION
https://github.com/towc/expressive-code-links#links

I couldn't find guidance on where I should put the entry in `community-plugins.mdx`. I couldn't find a pattern from `git blame` or looking at some of the previous PRs.

I think links would be used by a larger number of people than the other lovely plugins, if they knew it was an option, so I put it at the top. On the other hand, I didn't put a lot of effort into the presentation of the plugin, so might not be a good "top" plugin, although it might make plugin development seem less scary if people saw it was just a github repo. I'm going to stop trying to guess what the policy is, just let me know if a different placement is preferred :)

All the best!