### PR TITLE
Support local shiki transformers in code blocks

### DIFF
--- a/docs/src/content/docs/key-features/code-component.mdx
+++ b/docs/src/content/docs/key-features/code-component.mdx
@@ -253,3 +253,16 @@ If `preserveIndent` is `true`, this value is added to the indentation of the ori
 :::note
 This option only affects how the code block is displayed and does not change the actual code. When copied to the clipboard, the code will still contain the original unwrapped lines.
 :::
+
+### transformers
+
+<PropertySignature>
+- Type: [`ShikiTransformer[]`](/key-features/syntax-highlighting/#transformers)
+- Default: `[]`
+</PropertySignature>
+
+Defines [shiki transformers](/key-features/syntax-highlighting/#transformers) to apply to the specific code block.
+
+:::caution[Experimental option with very limited support]
+See the [associated page](/key-features/syntax-highlighting/#transformers) for more details.
+:::

--- a/internal/test-utils/src/html-snapshots.ts
+++ b/internal/test-utils/src/html-snapshots.ts
@@ -1,6 +1,14 @@
 import { mkdirSync, writeFileSync } from 'fs'
 import { join, dirname } from 'path'
-import { ExpressiveCodeEngine, ExpressiveCodeEngineConfig, ExpressiveCodePlugin, ExpressiveCodeTheme, StyleVariant } from '@expressive-code/core'
+import {
+	ExpressiveCodeBlockProps,
+	ExpressiveCodeEngine,
+	ExpressiveCodeEngineConfig,
+	ExpressiveCodePlugin,
+	ExpressiveCodeTheme,
+	PartialAllowUndefined,
+	StyleVariant,
+} from '@expressive-code/core'
 import type { Element } from '@expressive-code/core/hast'
 import { toHtml } from '@expressive-code/core/hast'
 
@@ -11,6 +19,7 @@ export type TestFixture = {
 	code: string
 	language?: string | undefined
 	meta?: string | undefined
+	props?: PartialAllowUndefined<ExpressiveCodeBlockProps> | undefined
 	themes?: ExpressiveCodeTheme[] | undefined
 	plugins: ExpressiveCodePlugin[]
 	engineOptions?: Partial<ExpressiveCodeEngineConfig> | undefined
@@ -26,7 +35,7 @@ export function buildThemeFixtures(themes: ExpressiveCodeTheme[], fixtureContent
 	return [fixture]
 }
 
-async function renderFixture({ fixtureName, code, language = 'js', meta = '', themes, plugins, engineOptions, blockValidationFn }: TestFixture) {
+async function renderFixture({ fixtureName, code, language = 'js', meta = '', props, themes, plugins, engineOptions, blockValidationFn }: TestFixture) {
 	const engine = new ExpressiveCodeEngine({
 		themes,
 		plugins,
@@ -39,6 +48,7 @@ async function renderFixture({ fixtureName, code, language = 'js', meta = '', th
 		code,
 		language,
 		meta,
+		props,
 	})
 
 	return {

--- a/packages/@expressive-code/plugin-shiki/src/transformers.ts
+++ b/packages/@expressive-code/plugin-shiki/src/transformers.ts
@@ -12,10 +12,10 @@ export type BaseHookArgs = {
 /**
  * Throws an error if any of the configured transformers use unsupported hooks.
  */
-export function validateTransformers(options: PluginShikiOptions) {
-	if (!options.transformers) return
+export function validateTransformers(transformers: PluginShikiOptions['transformers']) {
+	if (!transformers) return
 	const unsupportedTransformerHooks: (keyof ShikiTransformer)[] = ['code', 'line', 'postprocess', 'pre', 'root', 'span']
-	for (const transformer of coerceTransformers(options.transformers)) {
+	for (const transformer of coerceTransformers(transformers)) {
 		const unsupportedHook = unsupportedTransformerHooks.find((hook) => transformer[hook] != null)
 		if (unsupportedHook) {
 			throw new ExpressiveCodeShikiTransformerError(transformer, `The transformer hook "${unsupportedHook}" is not supported by Expressive Code yet.`)


### PR DESCRIPTION
This adds a `transformers` option to the code block props, which allows adding shiki transformers to a specific code block.

See this associated discussion for more background and motivation: https://github.com/expressive-code/expressive-code/discussions/425