### PR TITLE
Fix custom Markdown fixture by preloading JavaScript for nested fences

### DIFF
--- a/packages/astro-expressive-code/test/fixtures/astro-4.0.0/shiki-langs/custom-md.mjs
+++ b/packages/astro-expressive-code/test/fixtures/astro-4.0.0/shiki-langs/custom-md.mjs
@@ -3108,6 +3108,9 @@ const lang = {
 			while: '(^|\\G)(?=\\|)',
 		},
 	},
+	// Ensure nested JS fences are deterministic during parallel builds by preloading
+	// the bundled JavaScript grammar required by this markdown grammar
+	embeddedLangsLazy: ['javascript'],
 	scopeName: 'text.html.markdown',
 }
 


### PR DESCRIPTION
Fixes the flaky custom grammar test fixture. This was caused by a missing `embeddedLangsLazy` value in the custom grammar, not an actual EC bug.

Astro's parallel page rendering does not guarantee the order of pages during rendering. This caused the flakiness:
- During most test runs, other pages using the JS language for highlighting were rendered before the custom grammar test page, so the test succeeded.
- However, sometimes, the custom grammar page was the first one to be rendered, and due to the missing `embeddedLangsLazy` value, the JS grammar did not get loaded at all and was rendered as plain text, causing the test to fail.

Lesson learned: It's important to properly add all languages included by custom grammars to the `embeddedLangsLazy` array, or ensure otherwise that they get loaded, e.g. by adding them to the `langs` array in case of other custom languages.