### PR TITLE
docs: add `ec-lang-logo` to community plugins

### DIFF
--- a/docs/src/content/docs/plugins/community-plugins.mdx
+++ b/docs/src/content/docs/plugins/community-plugins.mdx
@@ -60,5 +60,10 @@ The community-maintained plugins on this page extend Expressive Code to add new 
 			title: 'expressive-code-typewriter',
 			description: 'Add typewriter-style typing animations to your code blocks',
 		},
+		{
+			href: 'https://github.com/DerTimonius/ec-lang-logo',
+			title: 'ec-lang-logo',
+			description: 'Add official language logos to your code blocks',
+		},
 	]}
 />


### PR DESCRIPTION
Thanks for this awesome package 🙏 

I have built a small plugin that shows the official logo of the used language at the bottom right of the codeblock:
<img width="1694" height="342" alt="image" src="https://github.com/user-attachments/assets/2de54f38-3a9c-4506-88ee-b63f38bfe95f" />
<img width="1700" height="670" alt="image" src="https://github.com/user-attachments/assets/94d5b7a6-5328-431b-b7c6-390a3fbedcf6" />

This PR adds my plugin to the list of community plugins in the docs.

https://github.com/DerTimonius/ec-lang-logo
[Blog post where I show more examples](https://blog.dertimonius.dev/posts/til-38)

