### PR TITLE
docs: add ec-magic-move plugin to community plugins

### DIFF
--- a/docs/src/content/docs/plugins/community-plugins.mdx
+++ b/docs/src/content/docs/plugins/community-plugins.mdx
@@ -65,5 +65,10 @@ The community-maintained plugins on this page extend Expressive Code to add new 
 			title: 'ec-lang-logo',
 			description: 'Add official language logos to your code blocks',
 		},
+    {
+			href: 'https://github.com/DerTimonius/ec-magic-move',
+			title: 'ec-magic-move',
+			description: 'Animate your code blocks with shiki-magic-move',
+		},
 	]}
 />


### PR DESCRIPTION
Hey, created a new plugin that ports `shiki-magic-move` to be usable directly in expressive code blocks. This PR adds it to the list of community plugins in the docs

Examples can be found in the repo's README https://github.com/DerTimonius/ec-magic-move