### PR TITLE
Internalize Sätteri plugin to improve dependency tree

### DIFF
--- a/.changeset/astro-satteri-support.md
+++ b/.changeset/astro-satteri-support.md
@@ -5,3 +5,5 @@
 Adds support for the [Sätteri Markdown processor](https://astro.build/blog/astro-640/) introduced in Astro 6.4.
 
 When your Astro config sets `markdown.processor` to `satteri()` (from `@astrojs/markdown-satteri`), code blocks are now processed by Expressive Code through an equivalent Sätteri HAST plugin instead of the rehype plugin, which Sätteri does not run. The default unified pipeline keeps working exactly as before, and no configuration changes are required to benefit from this.
+
+Thank you @Princesseuh!

--- a/.changeset/free-animals-tickle.md
+++ b/.changeset/free-animals-tickle.md
@@ -1,5 +1,0 @@
----
-'astro-expressive-code': minor
----
-
-Adds support for the new Sätteri Markdown processor introduced in Astro 6.4.0. Thank you @Princesseuh!

--- a/packages/astro-expressive-code/package.json
+++ b/packages/astro-expressive-code/package.json
@@ -56,8 +56,7 @@
     "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta"
   },
   "dependencies": {
-    "rehype-expressive-code": "workspace:^0.42.0",
-    "satteri-expressive-code": "^0.1.8"
+    "rehype-expressive-code": "workspace:^0.42.0"
   },
   "devDependencies": {
     "@internal/test-utils": "workspace:^",

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -4,7 +4,7 @@ import rehypeExpressiveCode from 'rehype-expressive-code'
 import { ConfigSetupHookArgs, PartialAstroConfig, isSatteriProcessor } from './astro-config'
 import { AstroExpressiveCodeOptions, CustomConfigPreprocessors, ConfigPreprocessorFn, getEcConfigFileUrl, loadEcConfigFile, mergeEcConfigOptions } from './ec-config'
 import { createAstroRenderer } from './renderer'
-import { addSatteriExpressiveCodePlugin } from './satteri'
+import { satteriExpressiveCodePlugin } from './satteri'
 import { vitePluginAstroExpressiveCode } from './vite-plugin'
 
 declare module 'rehype-expressive-code' {
@@ -94,7 +94,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				// equivalent Sätteri HAST plugin instead of injecting our rehype plugin.
 				const markdownProcessor = (astroConfig.markdown as { processor?: unknown } | undefined)?.processor
 				if (isSatteriProcessor(markdownProcessor)) {
-					await addSatteriExpressiveCodePlugin(markdownProcessor, rehypeExpressiveCodeOptions)
+					markdownProcessor.options.hastPlugins.push(() => satteriExpressiveCodePlugin(rehypeExpressiveCodeOptions))
 					updateConfig({ vite, markdown: { syntaxHighlight: false } })
 				} else {
 					updateConfig({

--- a/packages/astro-expressive-code/src/satteri.ts
+++ b/packages/astro-expressive-code/src/satteri.ts
@@ -1,42 +1,106 @@
-import type { RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
-import { ExpressiveCodeBlock } from 'rehype-expressive-code'
-import type { SatteriExpressiveCodeDocument, SatteriExpressiveCodeOptions, SatteriExpressiveCodeRenderer } from 'satteri-expressive-code'
-import type { SatteriMarkdownProcessor } from './astro-config'
+import type { HastPluginDefinition, HastVisitorContext } from 'satteri'
+import type { Element } from 'rehype-expressive-code/hast'
+import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions, RehypeExpressiveCodeRenderer } from 'rehype-expressive-code'
+import { createRenderer, ExpressiveCodeBlock } from 'rehype-expressive-code'
 
-export async function addSatteriExpressiveCodePlugin(markdownProcessor: SatteriMarkdownProcessor, options: RehypeExpressiveCodeOptions) {
-	const { default: satteriExpressiveCode } = await import('satteri-expressive-code')
-	markdownProcessor.options.hastPlugins.push(() => satteriExpressiveCode(createSatteriOptions(options))())
+type CodeBlockInfo = {
+	lang: string
+	text: string
+	meta: string
 }
 
-/**
- * Creates options for the Sätteri plugin based on the given rehype-expressive-code options,
- * allowing Astro users to switch between rehype and Sätteri without EC config changes.
- */
-function createSatteriOptions(options: RehypeExpressiveCodeOptions): SatteriExpressiveCodeOptions {
-	const { getBlockLocale, customCreateBlock, customCreateRenderer, ...ecOptions } = options
+export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions): HastPluginDefinition {
+	const { tabWidth = 2, getBlockLocale, customCreateRenderer } = options
+	const customCreateBlock = createSatteriBlockFactory(options.customCreateBlock)
+	let asyncRenderer: Promise<RehypeExpressiveCodeRenderer> | RehypeExpressiveCodeRenderer | undefined
+	let firstBlockClaimed = false
+
 	return {
-		...(ecOptions as Omit<SatteriExpressiveCodeOptions, 'getBlockLocale' | 'customCreateBlock' | 'customCreateRenderer'>),
-		getBlockLocale: getBlockLocale ? ({ input, document }) => getBlockLocale({ input, file: createSatteriDocumentFile(document) }) : undefined,
-		customCreateRenderer: customCreateRenderer ? () => customCreateRenderer(options) as SatteriExpressiveCodeRenderer | Promise<SatteriExpressiveCodeRenderer> : undefined,
-		// Sätteri calls HAST plugin factories once per compile, so creating the block factory
-		// here keeps the per-document group index state from leaking into later renders
-		// that reuse the same Astro Markdown processor.
-		customCreateBlock: createSatteriBlockFactory(customCreateBlock),
+		name: 'astro-expressive-code-satteri',
+		element: {
+			filter: ['pre'],
+			async visit(node, ctx) {
+				const codeBlockInfo = getCodeBlockInfo(node as Element)
+				if (!codeBlockInfo) return
+
+				const isFirstBlock = !firstBlockClaimed
+				firstBlockClaimed = true
+
+				if (asyncRenderer === undefined) {
+					asyncRenderer = (customCreateRenderer ?? createRenderer)(options)
+				}
+				const { ec, baseStyles, themeStyles, jsModules } = await asyncRenderer
+
+				let normalizedCode = codeBlockInfo.text
+				if (tabWidth > 0) normalizedCode = normalizedCode.replace(/\t/g, ' '.repeat(tabWidth))
+
+				const file = createSatteriDocumentFile(ctx)
+				const input: ExpressiveCodeBlockOptions = {
+					code: normalizedCode,
+					language: codeBlockInfo.lang,
+					meta: codeBlockInfo.meta,
+					parentDocument: {
+						sourceFilePath: ctx.filename,
+					},
+				}
+				if (getBlockLocale) {
+					input.locale = await getBlockLocale({ input, file })
+				}
+
+				const codeBlock = await customCreateBlock({ input, file })
+				const { renderedGroupAst, styles } = await ec.render(codeBlock)
+				const extraElements: Element[] = []
+				const stylesToPrepend: string[] = []
+
+				if (isFirstBlock) {
+					if (baseStyles) stylesToPrepend.push(baseStyles)
+					if (themeStyles) stylesToPrepend.push(themeStyles)
+				}
+				stylesToPrepend.push(...styles)
+				if (stylesToPrepend.length) {
+					extraElements.push({
+						type: 'element',
+						tagName: 'style',
+						properties: {},
+						children: [{ type: 'text', value: stylesToPrepend.join('') }],
+					})
+				}
+				if (isFirstBlock) {
+					jsModules.forEach((moduleCode) => {
+						extraElements.push({
+							type: 'element',
+							tagName: 'script',
+							properties: { type: 'module' },
+							children: [{ type: 'text', value: moduleCode }],
+						})
+					})
+				}
+				if (extraElements.length) {
+					const firstChild = renderedGroupAst.children.length > 0 ? renderedGroupAst.children[0] : undefined
+					const firstChildIsStyle = firstChild?.type === 'element' && ['style', 'link'].includes(firstChild.tagName)
+					const insertIndex = firstChildIsStyle ? 1 : 0
+					renderedGroupAst.children.splice(insertIndex, 0, ...extraElements)
+				}
+
+				return renderedGroupAst
+			},
+		},
 	}
 }
 
 /**
- * Creates a rehype-compatible `file` object from the given Sätteri document.
- * The resulting object includes the Sätteri document under the `data.satteri` key,
- * but also provides `path` and `cwd` properties expected by existing plugins and integrations
- * in the EC ecosystem.
+ * Creates a rehype-compatible `file` object as expected by existing EC plugins,
+ * but also includes the original data provided by Sätteri's visitor as `data.satteri`.
  */
-function createSatteriDocumentFile(document: SatteriExpressiveCodeDocument): RehypeExpressiveCodeDocument {
+function createSatteriDocumentFile(ctx: HastVisitorContext): RehypeExpressiveCodeDocument {
 	return {
-		path: document.filename,
+		path: ctx.filename,
 		cwd: typeof process !== 'undefined' ? process.cwd() : '/',
 		data: {
-			satteri: document,
+			satteri: {
+				source: ctx.source,
+				filename: ctx.filename,
+			},
 		},
 	}
 }
@@ -47,14 +111,28 @@ function createSatteriDocumentFile(document: SatteriExpressiveCodeDocument): Reh
  * order within a document, but our renderer uses this index to inject page-wide styles & scripts
  * exactly once per document (before the first block it processes for each source file).
  */
-function createSatteriBlockFactory(userCreateBlock: RehypeExpressiveCodeOptions['customCreateBlock']): NonNullable<SatteriExpressiveCodeOptions['customCreateBlock']> {
+function createSatteriBlockFactory(userCreateBlock: RehypeExpressiveCodeOptions['customCreateBlock']): NonNullable<RehypeExpressiveCodeOptions['customCreateBlock']> {
 	const groupIndexByDocument = new Map<string, number>()
-	return async ({ input, document }) => {
-		const documentKey = input.parentDocument?.sourceFilePath || document.filename || ''
+	return async ({ input, file }) => {
+		const documentKey = input.parentDocument?.sourceFilePath || file.path || ''
 		const groupIndex = groupIndexByDocument.get(documentKey) ?? 0
 		groupIndexByDocument.set(documentKey, groupIndex + 1)
 		input.parentDocument = { ...input.parentDocument, positionInDocument: { groupIndex } }
-		if (userCreateBlock) return userCreateBlock({ input, file: createSatteriDocumentFile(document) })
+		if (userCreateBlock) return userCreateBlock({ input, file })
 		return new ExpressiveCodeBlock(input)
+	}
+}
+
+function getCodeBlockInfo(pre: Element): CodeBlockInfo | undefined {
+	if (pre.tagName !== 'pre') return
+	const [code, ...rest] = pre.children
+	if (rest.length || !code || code.type !== 'element' || code.tagName !== 'code') return
+	const [text] = code.children
+	if (!text || text.type !== 'text') return
+	const data = code.data as { lang?: string; meta?: string } | undefined
+	return {
+		lang: data?.lang ?? '',
+		text: text.value,
+		meta: data?.meta ?? '',
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,9 +322,6 @@ importers:
       rehype-expressive-code:
         specifier: workspace:^0.42.0
         version: link:../rehype-expressive-code
-      satteri-expressive-code:
-        specifier: ^0.1.8
-        version: 0.1.8(satteri@0.6.3)
     devDependencies:
       '@internal/test-utils':
         specifier: workspace:^
@@ -7142,11 +7139,6 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  satteri-expressive-code@0.1.8:
-    resolution: {integrity: sha512-Uj2iwHL7AKK5XFeGw5SIWHXBkTUp1K1QpSJhoHhVqb/bM9lbJ/oY7lQVa+5ocVAuqcAiWSJicqBW85Ujcf056A==}
-    peerDependencies:
-      satteri: '>=0.4.0'
-
   satteri@0.6.3:
     resolution: {integrity: sha512-iY5xd2tBDQveYRFkL1F0cegkabWSVoXHi64e1p49SiCs1bZDaqTQPGQI+PqEQIaWkz0iqK80CuQQUYvhsssviw==}
 
@@ -13545,8 +13537,8 @@ snapshots:
       '@typescript-eslint/parser': 6.11.0(eslint@8.53.0)(typescript@5.9.3)
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.53.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.53.0)
       eslint-plugin-react: 7.34.1(eslint@8.53.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
@@ -13568,13 +13560,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.53.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0):
     dependencies:
       debug: 4.4.3
       enhanced-resolve: 5.16.0
       eslint: 8.53.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.53.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -13585,28 +13577,18 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.53.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 6.11.0(eslint@8.53.0)(typescript@5.9.3)
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.53.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.53.0):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
-      eslint: 8.53.0
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -13616,7 +13598,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.53.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.11.0(eslint@8.53.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@8.53.0))(eslint@8.53.0))(eslint@8.53.0)
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -13627,7 +13609,7 @@ snapshots:
       semver: 6.3.1
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.11.0(eslint@8.53.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -17320,11 +17302,6 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  satteri-expressive-code@0.1.8(satteri@0.6.3):
-    dependencies:
-      expressive-code: link:packages/expressive-code
-      satteri: 0.6.3
-
   satteri@0.6.3:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -18193,7 +18170,7 @@ snapshots:
 
   unenv-nightly@2.0.0-20241218-183400-5d6aec3:
     dependencies:
-      defu: 6.1.4
+      defu: 6.1.7
       mlly: 1.8.1
       ohash: 1.1.6
       pathe: 1.1.2


### PR DESCRIPTION
Some cleanup work after merging PR #445:
- Remove runtime dependency on `satteri-expressive-code` to avoid pulling in `satteri` into projects not using it.
- Internalize Sätteri HAST plugin code into `satteri.ts` and reuse `rehype-expressive-code` logic and types.
- Remove redundant changeset.