### PR TITLE
Fix half way render blocking external css for astro

### DIFF
--- a/packages/astro-expressive-code/components/Code.astro
+++ b/packages/astro-expressive-code/components/Code.astro
@@ -1,10 +1,13 @@
 ---
 import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument } from 'rehype-expressive-code'
 import { addClassName, toHtml } from 'rehype-expressive-code/hast'
-import type { Element, ElementContent } from 'rehype-expressive-code/hast'
+import type { ElementContent } from 'rehype-expressive-code/hast'
 import { getPageData } from './page-data'
 import { getRenderer } from './renderer'
 import type { CodeProps as Props } from './types'
+
+// Note: the content in this import will be empty if `emitExternalStylesheet` is set to false
+import 'virtual:astro-expressive-code/styles.css'
 
 function formatMessage(...messageParts: string[]) {
 	return messageParts.map((part) => part.replace(/\s+/g, ' ')).join('\n\n')

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -65,7 +65,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				delete processedEcConfig.customCreateAstroRenderer
 				delete processedEcConfig.customConfigPreprocessors
 
-				const { hashedStyles, hashedScripts, ...renderer } = await (customCreateAstroRenderer ?? createAstroRenderer)({ astroConfig, ecConfig: processedEcConfig, logger })
+				const { styles, hashedScripts, ...renderer } = await (customCreateAstroRenderer ?? createAstroRenderer)({ astroConfig, ecConfig: processedEcConfig, logger })
 
 				const rehypeExpressiveCodeOptions: RehypeExpressiveCodeOptions = {
 					// Even though we have created a custom renderer, some options are used
@@ -79,7 +79,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				const vite = {
 					plugins: [
 						vitePluginAstroExpressiveCode({
-							styles: hashedStyles,
+							styles,
 							scripts: hashedScripts,
 							ecIntegrationOptions: integrationOptions,
 							processedEcConfig,

--- a/packages/astro-expressive-code/src/renderer.ts
+++ b/packages/astro-expressive-code/src/renderer.ts
@@ -9,7 +9,7 @@ export type CreateAstroRendererArgs = {
 }
 
 export type AstroExpressiveCodeRenderer = RehypeExpressiveCodeRenderer & {
-	hashedStyles: [string, string][]
+	styles: string
 	hashedScripts: [string, string][]
 }
 
@@ -22,8 +22,7 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 
 	// Add a plugin that inserts external references to the styles and scripts
 	// that would normally be inlined into the first code block of every page
-	let inlineStyles = ''
-	const hashedStyles: [string, string][] = []
+	let styles: string = ''
 	const hashedScripts: [string, string][] = []
 	plugins.push({
 		name: 'astro-expressive-code',
@@ -36,23 +35,13 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 				type HastElement = Extract<(typeof renderData.groupAst.children)[number], { type: 'element' }>
 				const extraElements: HastElement[] = []
 
-				// Add hashed stylesheet links
-				hashedStyles.forEach(([hashedRoute]) => {
-					extraElements.push({
-						type: 'element',
-						tagName: 'link',
-						properties: { rel: 'stylesheet', href: `${getAssetsBaseHref('.css', astroConfig.build?.assetsPrefix, astroConfig.base)}${hashedRoute}` },
-						children: [],
-					})
-				})
-
 				// Add base inline styles (only present if not emitted as external stylesheet)
-				if (inlineStyles) {
+				if (!emitExternalStylesheet) {
 					extraElements.push({
 						type: 'element',
 						tagName: 'style',
 						properties: {},
-						children: [{ type: 'text', value: inlineStyles }],
+						children: [{ type: 'text', value: styles }],
 					})
 				}
 
@@ -88,20 +77,14 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 		shiki: mergedShikiConfig,
 		...rest,
 	})) as AstroExpressiveCodeRenderer
-	renderer.hashedStyles = hashedStyles
-	renderer.hashedScripts = hashedScripts
 
 	// Extract any base and theme styles from the child renderer, as they are handled by this
 	// integration. Our way of handling them depends on the emitExternalStylesheet option:
 	// - If it's true (which is the default), we move all base and theme styles
 	//   into an external CSS file with a hashed filename
 	// - If it's false, we inline them into the first code block of the page
-	if (emitExternalStylesheet) {
-		const combinedStyles = `${renderer.baseStyles}${renderer.themeStyles}`
-		hashedStyles.push(getHashedRouteWithContent(combinedStyles, `/${assetsDir}/ec.{hash}.css`))
-	} else {
-		inlineStyles = `${renderer.baseStyles}${renderer.themeStyles}`
-	}
+	const combinedStyles = `${renderer.baseStyles}${renderer.themeStyles}`
+	styles = combinedStyles
 	renderer.baseStyles = ''
 	renderer.themeStyles = ''
 
@@ -112,6 +95,9 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 	const mergedJsCode = uniqueJsModules.join('\n')
 	renderer.jsModules = []
 	hashedScripts.push(getHashedRouteWithContent(mergedJsCode, `/${assetsDir}/ec.{hash}.js`))
+
+	renderer.styles = styles
+	renderer.hashedScripts = hashedScripts
 
 	return renderer
 }

--- a/packages/astro-expressive-code/src/satteri.ts
+++ b/packages/astro-expressive-code/src/satteri.ts
@@ -1,8 +1,8 @@
-import type { HastPluginDefinition, HastVisitorContext } from 'satteri'
+import type { HastPluginDefinition, HastVisitorContext, MdxjsEsm } from 'satteri'
 import type { Element } from 'rehype-expressive-code/hast'
-import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions, RehypeExpressiveCodeRenderer } from 'rehype-expressive-code'
-import { createRenderer, ExpressiveCodeBlock } from 'rehype-expressive-code'
+import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
 import { fileURLToPath } from 'url-extras'
+import { CodeProps } from '../components/types'
 
 type CodeBlockInfo = {
 	lang: string
@@ -11,9 +11,7 @@ type CodeBlockInfo = {
 }
 
 export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions): HastPluginDefinition {
-	const { tabWidth = 2, getBlockLocale, customCreateRenderer } = options
-	const customCreateBlock = createSatteriBlockFactory(options.customCreateBlock)
-	let asyncRenderer: Promise<RehypeExpressiveCodeRenderer> | RehypeExpressiveCodeRenderer | undefined
+	const { tabWidth = 2, getBlockLocale } = options
 	let firstBlockClaimed = false
 
 	return {
@@ -27,11 +25,6 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 				const isFirstBlock = !firstBlockClaimed
 				firstBlockClaimed = true
 
-				if (asyncRenderer === undefined) {
-					asyncRenderer = (customCreateRenderer ?? createRenderer)(options)
-				}
-				const { ec, baseStyles, themeStyles, jsModules } = await asyncRenderer
-
 				let normalizedCode = codeBlockInfo.text
 				if (tabWidth > 0) normalizedCode = normalizedCode.replace(/\t/g, ' '.repeat(tabWidth))
 
@@ -44,46 +37,36 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 						sourceFilePath: file.path,
 					},
 				}
+				const codeProps: CodeProps = {
+					code: input.code,
+					lang: input.language,
+					meta: input.meta,
+				}
 				if (getBlockLocale) {
-					input.locale = await getBlockLocale({ input, file })
+					const locale = await getBlockLocale({ input, file })
+					if (locale) {
+						codeProps.locale = locale
+					}
 				}
-
-				const codeBlock = await customCreateBlock({ input, file })
-				const { renderedGroupAst, styles } = await ec.render(codeBlock)
-				const extraElements: Element[] = []
-				const stylesToPrepend: string[] = []
 
 				if (isFirstBlock) {
-					if (baseStyles) stylesToPrepend.push(baseStyles)
-					if (themeStyles) stylesToPrepend.push(themeStyles)
-				}
-				stylesToPrepend.push(...styles)
-				if (stylesToPrepend.length) {
-					extraElements.push({
-						type: 'element',
-						tagName: 'style',
-						properties: {},
-						children: [{ type: 'text', value: stylesToPrepend.join('') }],
-					})
-				}
-				if (isFirstBlock) {
-					jsModules.forEach((moduleCode) => {
-						extraElements.push({
-							type: 'element',
-							tagName: 'script',
-							properties: { type: 'module' },
-							children: [{ type: 'text', value: moduleCode }],
-						})
-					})
-				}
-				if (extraElements.length) {
-					const firstChild = renderedGroupAst.children.length > 0 ? renderedGroupAst.children[0] : undefined
-					const firstChildIsStyle = firstChild?.type === 'element' && ['style', 'link'].includes(firstChild.tagName)
-					const insertIndex = firstChildIsStyle ? 1 : 0
-					renderedGroupAst.children.splice(insertIndex, 0, ...extraElements)
+					ctx.insertBefore(node, {
+						type: 'mdxjsEsm',
+						value: "import { Code as ExpressiveCodeInternal } from 'astro-expressive-code/components'",
+					} as MdxjsEsm)
 				}
 
-				return renderedGroupAst
+				return {
+					type: 'mdxJsxFlowElement',
+					name: 'ExpressiveCodeInternal',
+					attributes: Object.entries(codeProps).map(([key, value]) => ({
+						type: 'mdxJsxAttribute',
+						name: key,
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						value,
+					})),
+					children: [],
+				}
 			},
 		},
 	}
@@ -120,24 +103,6 @@ function createSatteriDocumentFile(ctx: HastVisitorContext): RehypeExpressiveCod
 				fileURL,
 			},
 		},
-	}
-}
-
-/**
- * Wraps an optional user `customCreateBlock` so that every code block created by the Sätteri plugin
- * receives a `positionInDocument.groupIndex`. Sätteri visits code blocks without tracking their
- * order within a document, but our renderer uses this index to inject page-wide styles & scripts
- * exactly once per document (before the first block it processes for each source file).
- */
-function createSatteriBlockFactory(userCreateBlock: RehypeExpressiveCodeOptions['customCreateBlock']): NonNullable<RehypeExpressiveCodeOptions['customCreateBlock']> {
-	const groupIndexByDocument = new Map<string, number>()
-	return async ({ input, file }) => {
-		const documentKey = input.parentDocument?.sourceFilePath || file.path || ''
-		const groupIndex = groupIndexByDocument.get(documentKey) ?? 0
-		groupIndexByDocument.set(documentKey, groupIndex + 1)
-		input.parentDocument = { ...input.parentDocument, positionInDocument: { groupIndex } }
-		if (userCreateBlock) return userCreateBlock({ input, file })
-		return new ExpressiveCodeBlock(input)
 	}
 }
 

--- a/packages/astro-expressive-code/src/vite-plugin.ts
+++ b/packages/astro-expressive-code/src/vite-plugin.ts
@@ -20,14 +20,17 @@ export function vitePluginAstroExpressiveCode({
 	astroConfig,
 	command,
 }: {
-	styles: [string, string][]
+	styles: string
 	scripts: [string, string][]
 	ecIntegrationOptions: AstroExpressiveCodeOptions
 	processedEcConfig: AstroExpressiveCodeOptions
 	astroConfig: PartialAstroConfig
 	command: HookParameters<'astro:config:setup'>['command']
 }): NonNullable<ViteUserConfig['plugins']>[number] {
-	const modules: Record<string, string> = {}
+	// Map virtual module names to their code contents as strings
+	const modules: Record<string, string> = {
+		'virtual:astro-expressive-code/styles.css': processedEcConfig.emitExternalStylesheet === false ? '' : styles,
+	}
 
 	// Create virtual config module
 	const configModuleContents: string[] = []
@@ -72,7 +75,7 @@ export function vitePluginAstroExpressiveCode({
 	const getVirtualModuleContents = (source: string) => {
 		// In dev mode, serve the extracted styles & scripts as virtual modules
 		if (command === 'dev') {
-			for (const file of [...styles, ...scripts]) {
+			for (const file of scripts) {
 				const [fileName, contents] = file
 				if (noQuery(fileName) === noQuery(source)) return contents
 			}
@@ -96,7 +99,7 @@ export function vitePluginAstroExpressiveCode({
 					if (resolved) return resolved
 				}
 				// Resolve other virtual modules
-				if (getVirtualModuleContents(source)) return `\0${source}`
+				if (getVirtualModuleContents(source) !== undefined) return `\0${source}`
 			},
 			load: (id) => (id?.[0] === '\0' ? getVirtualModuleContents(id.slice(1)) : undefined),
 			// If any file imported by the EC config file changes, restart the server
@@ -144,12 +147,12 @@ export function vitePluginAstroExpressiveCode({
 			},
 		},
 		// Add a second plugin that only runs in build mode (to avoid Vite warnings about emitFile)
-		// which emits the extracted styles & scripts as static assets
+		// which emits the extracted scripts as static assets
 		{
 			name: 'vite-plugin-astro-expressive-code-build',
 			apply: 'build',
 			buildEnd() {
-				for (const file of [...styles, ...scripts]) {
+				for (const file of scripts) {
 					const [fileName, source] = file
 					this.emitFile({
 						type: 'asset',

--- a/packages/astro-expressive-code/virtual.d.ts
+++ b/packages/astro-expressive-code/virtual.d.ts
@@ -15,3 +15,5 @@ declare module 'virtual:astro-expressive-code/api' {
 	export const createAstroRenderer: typeof import('astro-expressive-code').createAstroRenderer
 	export const mergeEcConfigOptions: typeof import('astro-expressive-code').mergeEcConfigOptions
 }
+
+declare module 'virtual:astro-expressive-code/styles.css'


### PR DESCRIPTION
Fix #452

Use astro's [external stylesheet imports](https://docs.astro.build/en/guides/styling/#import-a-local-stylesheet) and vite's virtual modules instead of manually emitting the css as files and add them to the html. This avoids duplications (yes it can happen if `<Code />` is used by different parts like a MDX file and a .astro file) and the half way render blocking that causes unpleasant layout shifts.
(this should probably be done to the js as well)

This reverts part of the removal of the virtual module from #187, but instead of js, it returns the css code.

I have not fixed the tests and added change logs yet, so marking as draft for now.