### PR TITLE
Adding a new option `injectCssAndJs` for astro

### DIFF
--- a/.changeset/astro-injectCssAndJs.md
+++ b/.changeset/astro-injectCssAndJs.md
@@ -1,0 +1,10 @@
+---
+astro-expressive-code: patch
+---
+
+Added a new option `injectCssAndJs` that allows you to disable the embedded external css that blocks the rendering half ways completely or injecting it to the head to every file instead.
+
+And added the following virtual modules
+
+- `virtual:astro-expressive-code/styles.css`
+- `virtual:astro-expressive-code/scripts.js`

--- a/docs/ec.config.mjs
+++ b/docs/ec.config.mjs
@@ -20,4 +20,6 @@ export default defineEcConfig({
 	defaultProps: {
 		showLineNumbers: false,
 	},
+	// Since our docs site contains code blocks on almost every page, the trade off makes sense
+	injectCssAndJs: 'head',
 })

--- a/packages/astro-expressive-code/components/Code.astro
+++ b/packages/astro-expressive-code/components/Code.astro
@@ -6,9 +6,6 @@ import { getPageData } from './page-data'
 import { getRenderer } from './renderer'
 import type { CodeProps as Props } from './types'
 
-// Note: the content in this import will be empty if `emitExternalStylesheet` is set to false
-import 'virtual:astro-expressive-code/styles.css'
-
 function formatMessage(...messageParts: string[]) {
 	return messageParts.map((part) => part.replace(/\s+/g, ' ')).join('\n\n')
 }

--- a/packages/astro-expressive-code/components/Code.astro
+++ b/packages/astro-expressive-code/components/Code.astro
@@ -1,10 +1,13 @@
 ---
 import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument } from 'rehype-expressive-code'
 import { addClassName, toHtml } from 'rehype-expressive-code/hast'
-import type { Element, ElementContent } from 'rehype-expressive-code/hast'
+import type { ElementContent } from 'rehype-expressive-code/hast'
 import { getPageData } from './page-data'
 import { getRenderer } from './renderer'
 import type { CodeProps as Props } from './types'
+
+// Note: the content in this import will be empty if `emitExternalStylesheet` is set to false
+import 'virtual:astro-expressive-code/styles.css'
 
 function formatMessage(...messageParts: string[]) {
 	return messageParts.map((part) => part.replace(/\s+/g, ' ')).join('\n\n')

--- a/packages/astro-expressive-code/src/ec-config.ts
+++ b/packages/astro-expressive-code/src/ec-config.ts
@@ -23,6 +23,23 @@ export type AstroExpressiveCodeOptions = RehypeExpressiveCodeOptions & {
 	 */
 	emitExternalStylesheet?: boolean | undefined
 	/**
+	 * Controls how the CSS and JavaScript for expressive code blocks are injected.
+	 *
+	 * - `'inline'` - Inject the CSS and JavaScript inside each rendered `<Code />` Astro component and fenced code block in Markdown files.
+	 *   Note this might cause the browser to render half of the page then when encountered the first code block,
+	 *   it will be blocked to get the CSS and then render the rest of the page,
+	 *   this might also injected them multiple times in some cases.
+	 * - `'head'` - Inject the CSS and JavaScript once into the document `<head>`.
+	 *   Note this will inject them to every page.
+	 * - `'none'` - Do not inject any CSS or JavaScript.
+	 *   You can import them in your Astro components through
+	 * 	 `import virtual:astro-expressive-code/styles.css` in the font matter
+	 * 	 and `<script src="virtual:astro-expressive-code/scripts.js"></script>`.
+	 *
+	 * @default 'inline'
+	 */
+	injectCssAndJs?: 'inline' | 'head' | 'none'
+	/**
 	 * This advanced option allows you to influence the rendering process by creating
 	 * your own `AstroExpressiveCodeRenderer` or processing the base styles and JS modules
 	 * added to every page.

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -35,9 +35,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 	const integration = {
 		name: 'astro-expressive-code',
 		hooks: {
-			'astro:config:setup': async (args: unknown) => {
-				const { command, config: astroConfig, updateConfig, logger, addWatchFile } = args as ConfigSetupHookArgs
-
+			'astro:config:setup': async ({ command, config: astroConfig, updateConfig, logger, addWatchFile, injectScript }: ConfigSetupHookArgs) => {
 				// Validate Astro configuration
 				const ownPosition = astroConfig.integrations.findIndex((integration) => integration.name === 'astro-expressive-code')
 				const mdxPosition = astroConfig.integrations.findIndex((integration) => integration.name === '@astrojs/mdx')
@@ -66,6 +64,11 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				delete processedEcConfig.customConfigPreprocessors
 
 				const { styles, hashedScripts, ...renderer } = await (customCreateAstroRenderer ?? createAstroRenderer)({ astroConfig, ecConfig: processedEcConfig, logger })
+
+				if (processedEcConfig.injectCssAndJs === 'head') {
+					injectScript('page-ssr', 'import "virtual:astro-expressive-code/styles.css"')
+					injectScript('page', hashedScripts.content)
+				}
 
 				const rehypeExpressiveCodeOptions: RehypeExpressiveCodeOptions = {
 					// Even though we have created a custom renderer, some options are used

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -65,7 +65,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				delete processedEcConfig.customCreateAstroRenderer
 				delete processedEcConfig.customConfigPreprocessors
 
-				const { hashedStyles, hashedScripts, ...renderer } = await (customCreateAstroRenderer ?? createAstroRenderer)({ astroConfig, ecConfig: processedEcConfig, logger })
+				const { styles, hashedScripts, ...renderer } = await (customCreateAstroRenderer ?? createAstroRenderer)({ astroConfig, ecConfig: processedEcConfig, logger })
 
 				const rehypeExpressiveCodeOptions: RehypeExpressiveCodeOptions = {
 					// Even though we have created a custom renderer, some options are used
@@ -79,7 +79,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				const vite = {
 					plugins: [
 						vitePluginAstroExpressiveCode({
-							styles: hashedStyles,
+							styles,
 							scripts: hashedScripts,
 							ecIntegrationOptions: integrationOptions,
 							processedEcConfig,

--- a/packages/astro-expressive-code/src/index.ts
+++ b/packages/astro-expressive-code/src/index.ts
@@ -63,7 +63,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				delete processedEcConfig.customCreateAstroRenderer
 				delete processedEcConfig.customConfigPreprocessors
 
-				const { styles, hashedScripts, ...renderer } = await (customCreateAstroRenderer ?? createAstroRenderer)({ astroConfig, ecConfig: processedEcConfig, logger })
+				const { hashedStyles, hashedScripts, ...renderer } = await (customCreateAstroRenderer ?? createAstroRenderer)({ astroConfig, ecConfig: processedEcConfig, logger })
 
 				if (processedEcConfig.injectCssAndJs === 'head') {
 					injectScript('page-ssr', 'import "virtual:astro-expressive-code/styles.css"')
@@ -82,7 +82,7 @@ export function astroExpressiveCode(integrationOptions: AstroExpressiveCodeOptio
 				const vite = {
 					plugins: [
 						vitePluginAstroExpressiveCode({
-							styles,
+							styles: hashedStyles,
 							scripts: hashedScripts,
 							ecIntegrationOptions: integrationOptions,
 							processedEcConfig,

--- a/packages/astro-expressive-code/src/renderer.ts
+++ b/packages/astro-expressive-code/src/renderer.ts
@@ -9,7 +9,7 @@ export type CreateAstroRendererArgs = {
 }
 
 export type AstroExpressiveCodeRenderer = RehypeExpressiveCodeRenderer & {
-	styles: string
+	hashedStyles: { route: string; content: string }
 	hashedScripts: { route: string; content: string }
 }
 
@@ -23,8 +23,10 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 	const injectCssAndJs = ecConfig.injectCssAndJs ?? 'inline'
 	const injectCssAndJsInline = injectCssAndJs === 'inline'
 
-	let styles: string = ''
-	const hashedScripts: [string, string][] = []
+	// eslint-disable-next-line prefer-const
+	let hashedStyles: { route: string; content: string }
+	// eslint-disable-next-line prefer-const
+	let hashedScripts: { route: string; content: string }
 
 	if (injectCssAndJsInline) {
 		// Add a plugin that inserts external references to the styles and scripts
@@ -33,6 +35,9 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 			name: 'astro-expressive-code',
 			hooks: {
 				postprocessRenderedBlockGroup: ({ renderData, renderedGroupContents }) => {
+					if (!(hashedStyles && hashedScripts)) {
+						return
+					}
 					// Only continue if this is the first code block group of the page
 					const isFirstGroupInDocument = renderedGroupContents[0]?.codeBlock.parentDocument?.positionInDocument?.groupIndex === 0
 					if (!isFirstGroupInDocument) return
@@ -40,24 +45,30 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 					type HastElement = Extract<(typeof renderData.groupAst.children)[number], { type: 'element' }>
 					const extraElements: HastElement[] = []
 
-					// Add base inline styles (only present if not emitted as external stylesheet)
-					if (!emitExternalStylesheet) {
+					if (emitExternalStylesheet) {
+						// Add hashed stylesheet links
+						extraElements.push({
+							type: 'element',
+							tagName: 'link',
+							properties: { rel: 'stylesheet', href: `${getAssetsBaseHref('.css', astroConfig.build?.assetsPrefix, astroConfig.base)}${hashedStyles.route}` },
+							children: [],
+						})
+					} else {
+						// Add base inline styles (only present if not emitted as external stylesheet)
 						extraElements.push({
 							type: 'element',
 							tagName: 'style',
 							properties: {},
-							children: [{ type: 'text', value: styles }],
+							children: [{ type: 'text', value: hashedStyles.content }],
 						})
 					}
 
 					// Add hashed script module links for all JS modules
-					hashedScripts.forEach(([hashedRoute]) => {
-						extraElements.push({
-							type: 'element',
-							tagName: 'script',
-							properties: { type: 'module', src: `${getAssetsBaseHref('.js', astroConfig.build?.assetsPrefix, astroConfig.base)}${hashedRoute}` },
-							children: [],
-						})
+					extraElements.push({
+						type: 'element',
+						tagName: 'script',
+						properties: { type: 'module', src: `${getAssetsBaseHref('.js', astroConfig.build?.assetsPrefix, astroConfig.base)}${hashedScripts.route}` },
+						children: [],
 					})
 
 					if (!extraElements.length) return
@@ -90,7 +101,8 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 	//   into an external CSS file with a hashed filename
 	// - If it's false, we inline them into the first code block of the page
 	const combinedStyles = `${renderer.baseStyles}${renderer.themeStyles}`
-	styles = combinedStyles
+	hashedStyles = getHashedRouteWithContent(combinedStyles, `/${assetsDir}/ec.{hash}.css`)
+	renderer.hashedStyles = hashedStyles
 	renderer.baseStyles = ''
 	renderer.themeStyles = ''
 
@@ -99,10 +111,9 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 	// does not allow omitting the scripts on pages without any code blocks)
 	const uniqueJsModules = [...new Set<string>(renderer.jsModules)]
 	const mergedJsCode = uniqueJsModules.join('\n')
+	hashedScripts = getHashedRouteWithContent(mergedJsCode, `/${assetsDir}/ec.{hash}.js`)
+	renderer.hashedScripts = hashedScripts
 	renderer.jsModules = []
-
-	renderer.styles = styles
-	renderer.hashedScripts = getHashedRouteWithContent(mergedJsCode, `/${assetsDir}/ec.{hash}.js`)
 
 	return renderer
 }

--- a/packages/astro-expressive-code/src/renderer.ts
+++ b/packages/astro-expressive-code/src/renderer.ts
@@ -9,7 +9,7 @@ export type CreateAstroRendererArgs = {
 }
 
 export type AstroExpressiveCodeRenderer = RehypeExpressiveCodeRenderer & {
-	hashedStyles: [string, string][]
+	styles: string
 	hashedScripts: [string, string][]
 }
 
@@ -22,8 +22,7 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 
 	// Add a plugin that inserts external references to the styles and scripts
 	// that would normally be inlined into the first code block of every page
-	let inlineStyles = ''
-	const hashedStyles: [string, string][] = []
+	let styles: string = ''
 	const hashedScripts: [string, string][] = []
 	plugins.push({
 		name: 'astro-expressive-code',
@@ -36,23 +35,13 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 				type HastElement = Extract<(typeof renderData.groupAst.children)[number], { type: 'element' }>
 				const extraElements: HastElement[] = []
 
-				// Add hashed stylesheet links
-				hashedStyles.forEach(([hashedRoute]) => {
-					extraElements.push({
-						type: 'element',
-						tagName: 'link',
-						properties: { rel: 'stylesheet', href: `${getAssetsBaseHref('.css', astroConfig.build?.assetsPrefix, astroConfig.base)}${hashedRoute}` },
-						children: [],
-					})
-				})
-
 				// Add base inline styles (only present if not emitted as external stylesheet)
-				if (inlineStyles) {
+				if (!emitExternalStylesheet) {
 					extraElements.push({
 						type: 'element',
 						tagName: 'style',
 						properties: {},
-						children: [{ type: 'text', value: inlineStyles }],
+						children: [{ type: 'text', value: styles }],
 					})
 				}
 
@@ -88,20 +77,14 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 		shiki: mergedShikiConfig,
 		...rest,
 	})) as AstroExpressiveCodeRenderer
-	renderer.hashedStyles = hashedStyles
-	renderer.hashedScripts = hashedScripts
 
 	// Extract any base and theme styles from the child renderer, as they are handled by this
 	// integration. Our way of handling them depends on the emitExternalStylesheet option:
 	// - If it's true (which is the default), we move all base and theme styles
 	//   into an external CSS file with a hashed filename
 	// - If it's false, we inline them into the first code block of the page
-	if (emitExternalStylesheet) {
-		const combinedStyles = `${renderer.baseStyles}${renderer.themeStyles}`
-		hashedStyles.push(getHashedRouteWithContent(combinedStyles, `/${assetsDir}/ec.{hash}.css`))
-	} else {
-		inlineStyles = `${renderer.baseStyles}${renderer.themeStyles}`
-	}
+	const combinedStyles = `${renderer.baseStyles}${renderer.themeStyles}`
+	styles = combinedStyles
 	renderer.baseStyles = ''
 	renderer.themeStyles = ''
 
@@ -112,6 +95,9 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 	const mergedJsCode = uniqueJsModules.join('\n')
 	renderer.jsModules = []
 	hashedScripts.push(getHashedRouteWithContent(mergedJsCode, `/${assetsDir}/ec.{hash}.js`))
+
+	renderer.styles = styles
+	renderer.hashedScripts = hashedScripts
 
 	return renderer
 }

--- a/packages/astro-expressive-code/src/renderer.ts
+++ b/packages/astro-expressive-code/src/renderer.ts
@@ -10,7 +10,7 @@ export type CreateAstroRendererArgs = {
 
 export type AstroExpressiveCodeRenderer = RehypeExpressiveCodeRenderer & {
 	styles: string
-	hashedScripts: [string, string][]
+	hashedScripts: { route: string; content: string }
 }
 
 export async function createAstroRenderer({ ecConfig, astroConfig, logger }: CreateAstroRendererArgs): Promise<AstroExpressiveCodeRenderer> {
@@ -94,10 +94,9 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 	const uniqueJsModules = [...new Set<string>(renderer.jsModules)]
 	const mergedJsCode = uniqueJsModules.join('\n')
 	renderer.jsModules = []
-	hashedScripts.push(getHashedRouteWithContent(mergedJsCode, `/${assetsDir}/ec.{hash}.js`))
 
 	renderer.styles = styles
-	renderer.hashedScripts = hashedScripts
+	renderer.hashedScripts = getHashedRouteWithContent(mergedJsCode, `/${assetsDir}/ec.{hash}.js`)
 
 	return renderer
 }
@@ -105,7 +104,7 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 /**
  * Generates a hashed route and content tuple for a given content string.
  */
-function getHashedRouteWithContent(content: string, routeTemplate: string): [string, string] {
+function getHashedRouteWithContent(content: string, routeTemplate: string): { route: string; content: string } {
 	const contentHash = getStableObjectHash(content, { hashLength: 5 })
-	return [routeTemplate.replace('{hash}', contentHash), content]
+	return { route: routeTemplate.replace('{hash}', contentHash), content }
 }

--- a/packages/astro-expressive-code/src/renderer.ts
+++ b/packages/astro-expressive-code/src/renderer.ts
@@ -20,46 +20,52 @@ export async function createAstroRenderer({ ecConfig, astroConfig, logger }: Cre
 	// Determine the assets directory and href prefix from the Astro config
 	const assetsDir = astroConfig.build?.assets || '_astro'
 
-	// Add a plugin that inserts external references to the styles and scripts
-	// that would normally be inlined into the first code block of every page
+	const injectCssAndJs = ecConfig.injectCssAndJs ?? 'inline'
+	const injectCssAndJsInline = injectCssAndJs === 'inline'
+
 	let styles: string = ''
 	const hashedScripts: [string, string][] = []
-	plugins.push({
-		name: 'astro-expressive-code',
-		hooks: {
-			postprocessRenderedBlockGroup: ({ renderData, renderedGroupContents }) => {
-				// Only continue if this is the first code block group of the page
-				const isFirstGroupInDocument = renderedGroupContents[0]?.codeBlock.parentDocument?.positionInDocument?.groupIndex === 0
-				if (!isFirstGroupInDocument) return
 
-				type HastElement = Extract<(typeof renderData.groupAst.children)[number], { type: 'element' }>
-				const extraElements: HastElement[] = []
+	if (injectCssAndJsInline) {
+		// Add a plugin that inserts external references to the styles and scripts
+		// that would normally be inlined into the first code block of every page
+		plugins.push({
+			name: 'astro-expressive-code',
+			hooks: {
+				postprocessRenderedBlockGroup: ({ renderData, renderedGroupContents }) => {
+					// Only continue if this is the first code block group of the page
+					const isFirstGroupInDocument = renderedGroupContents[0]?.codeBlock.parentDocument?.positionInDocument?.groupIndex === 0
+					if (!isFirstGroupInDocument) return
 
-				// Add base inline styles (only present if not emitted as external stylesheet)
-				if (!emitExternalStylesheet) {
-					extraElements.push({
-						type: 'element',
-						tagName: 'style',
-						properties: {},
-						children: [{ type: 'text', value: styles }],
+					type HastElement = Extract<(typeof renderData.groupAst.children)[number], { type: 'element' }>
+					const extraElements: HastElement[] = []
+
+					// Add base inline styles (only present if not emitted as external stylesheet)
+					if (!emitExternalStylesheet) {
+						extraElements.push({
+							type: 'element',
+							tagName: 'style',
+							properties: {},
+							children: [{ type: 'text', value: styles }],
+						})
+					}
+
+					// Add hashed script module links for all JS modules
+					hashedScripts.forEach(([hashedRoute]) => {
+						extraElements.push({
+							type: 'element',
+							tagName: 'script',
+							properties: { type: 'module', src: `${getAssetsBaseHref('.js', astroConfig.build?.assetsPrefix, astroConfig.base)}${hashedRoute}` },
+							children: [],
+						})
 					})
-				}
 
-				// Add hashed script module links for all JS modules
-				hashedScripts.forEach(([hashedRoute]) => {
-					extraElements.push({
-						type: 'element',
-						tagName: 'script',
-						properties: { type: 'module', src: `${getAssetsBaseHref('.js', astroConfig.build?.assetsPrefix, astroConfig.base)}${hashedRoute}` },
-						children: [],
-					})
-				})
-
-				if (!extraElements.length) return
-				renderData.groupAst.children.unshift(...extraElements)
+					if (!extraElements.length) return
+					renderData.groupAst.children.unshift(...extraElements)
+				},
 			},
-		},
-	})
+		})
+	}
 
 	// Unless Shiki was disabled, merge any supported Shiki settings
 	// from the Astro config into the plugin options

--- a/packages/astro-expressive-code/src/satteri.ts
+++ b/packages/astro-expressive-code/src/satteri.ts
@@ -37,17 +37,13 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 						sourceFilePath: file.path,
 					},
 				}
-				const codeProps: CodeProps = {
+				const locale = await getBlockLocale?.({ input, file })
+				const codeProps = {
 					code: input.code,
 					lang: input.language,
 					meta: input.meta,
-				}
-				if (getBlockLocale) {
-					const locale = await getBlockLocale({ input, file })
-					if (locale) {
-						codeProps.locale = locale
-					}
-				}
+					locale,
+				} satisfies CodeProps
 
 				if (isFirstBlock) {
 					ctx.insertBefore(node, {
@@ -59,12 +55,13 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 				return {
 					type: 'mdxJsxFlowElement',
 					name: 'ExpressiveCodeInternal',
-					attributes: Object.entries(codeProps).map(([key, value]) => ({
-						type: 'mdxJsxAttribute',
-						name: key,
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-						value,
-					})),
+					attributes: Object.entries(codeProps)
+						.filter(([_, value]) => value)
+						.map(([key, value]) => ({
+							type: 'mdxJsxAttribute',
+							name: key,
+							value,
+						})),
 					children: [],
 				}
 			},

--- a/packages/astro-expressive-code/src/satteri.ts
+++ b/packages/astro-expressive-code/src/satteri.ts
@@ -1,8 +1,8 @@
-import type { HastPluginDefinition, HastVisitorContext } from 'satteri'
+import type { HastPluginDefinition, HastVisitorContext, MdxjsEsm } from 'satteri'
 import type { Element } from 'rehype-expressive-code/hast'
-import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions, RehypeExpressiveCodeRenderer } from 'rehype-expressive-code'
-import { createRenderer, ExpressiveCodeBlock } from 'rehype-expressive-code'
+import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
 import { fileURLToPath } from 'url-extras'
+import { CodeProps } from '../components/types'
 
 type CodeBlockInfo = {
 	lang: string
@@ -11,9 +11,7 @@ type CodeBlockInfo = {
 }
 
 export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions): HastPluginDefinition {
-	const { tabWidth = 2, getBlockLocale, customCreateRenderer } = options
-	const customCreateBlock = createSatteriBlockFactory(options.customCreateBlock)
-	let asyncRenderer: Promise<RehypeExpressiveCodeRenderer> | RehypeExpressiveCodeRenderer | undefined
+	const { tabWidth = 2, getBlockLocale } = options
 	let firstBlockClaimed = false
 
 	return {
@@ -27,11 +25,6 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 				const isFirstBlock = !firstBlockClaimed
 				firstBlockClaimed = true
 
-				if (asyncRenderer === undefined) {
-					asyncRenderer = (customCreateRenderer ?? createRenderer)(options)
-				}
-				const { ec, baseStyles, themeStyles, jsModules } = await asyncRenderer
-
 				let normalizedCode = codeBlockInfo.text
 				if (tabWidth > 0) normalizedCode = normalizedCode.replace(/\t/g, ' '.repeat(tabWidth))
 
@@ -44,46 +37,36 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 						sourceFilePath: file.path,
 					},
 				}
+				const codeProps: CodeProps = {
+					code: input.code,
+					lang: input.language,
+					meta: input.meta,
+				}
 				if (getBlockLocale) {
-					input.locale = await getBlockLocale({ input, file })
+					const locale = await getBlockLocale({ input, file })
+					if (locale) {
+						codeProps.locale = locale
+					}
 				}
-
-				const codeBlock = await customCreateBlock({ input, file })
-				const { renderedGroupAst, styles } = await ec.render(codeBlock)
-				const extraElements: Element[] = []
-				const stylesToPrepend: string[] = []
 
 				if (isFirstBlock) {
-					if (baseStyles) stylesToPrepend.push(baseStyles)
-					if (themeStyles) stylesToPrepend.push(themeStyles)
-				}
-				stylesToPrepend.push(...styles)
-				if (stylesToPrepend.length) {
-					extraElements.push({
-						type: 'element',
-						tagName: 'style',
-						properties: {},
-						children: [{ type: 'text', value: stylesToPrepend.join('') }],
-					})
-				}
-				if (isFirstBlock) {
-					jsModules.forEach((moduleCode) => {
-						extraElements.push({
-							type: 'element',
-							tagName: 'script',
-							properties: { type: 'module' },
-							children: [{ type: 'text', value: moduleCode }],
-						})
-					})
-				}
-				if (extraElements.length) {
-					const firstChild = renderedGroupAst.children.length > 0 ? renderedGroupAst.children[0] : undefined
-					const firstChildIsStyle = firstChild?.type === 'element' && ['style', 'link'].includes(firstChild.tagName)
-					const insertIndex = firstChildIsStyle ? 1 : 0
-					renderedGroupAst.children.splice(insertIndex, 0, ...extraElements)
+					ctx.insertBefore(node, {
+						type: 'mdxjsEsm',
+						value: "import { Code as ExpressiveCodeInternal } from 'astro-expressive-code/components'",
+					} as MdxjsEsm)
 				}
 
-				return renderedGroupAst
+				return {
+					type: 'mdxJsxFlowElement',
+					name: 'ExpressiveCodeInternal',
+					attributes: Object.entries(codeProps).map(([key, value]) => ({
+						type: 'mdxJsxAttribute',
+						name: key,
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+						value,
+					})),
+					children: [],
+				}
 			},
 		},
 	}
@@ -120,24 +103,6 @@ function createSatteriDocumentFile(ctx: HastVisitorContext): RehypeExpressiveCod
 				fileURL,
 			},
 		},
-	}
-}
-
-/**
- * Wraps an optional user `customCreateBlock` so that every code block created by the Sätteri plugin
- * receives a `positionInDocument.groupIndex`. Sätteri visits code blocks without tracking their
- * order within a document, but our renderer uses this index to inject page-wide styles & scripts
- * exactly once per document (before the first block it processes for each source file).
- */
-function createSatteriBlockFactory(userCreateBlock: RehypeExpressiveCodeOptions['customCreateBlock']): NonNullable<RehypeExpressiveCodeOptions['customCreateBlock']> {
-	const groupIndexByDocument = new Map<string, number>()
-	return async ({ input, file }) => {
-		const documentKey = input.parentDocument?.sourceFilePath || file.path || ''
-		const groupIndex = groupIndexByDocument.get(documentKey) ?? 0
-		groupIndexByDocument.set(documentKey, groupIndex + 1)
-		input.parentDocument = { ...input.parentDocument, positionInDocument: { groupIndex } }
-		if (userCreateBlock) return userCreateBlock({ input, file })
-		return new ExpressiveCodeBlock(input)
 	}
 }
 

--- a/packages/astro-expressive-code/src/satteri.ts
+++ b/packages/astro-expressive-code/src/satteri.ts
@@ -1,8 +1,8 @@
-import type { HastPluginDefinition, HastVisitorContext, MdxjsEsm } from 'satteri'
+import type { HastPluginDefinition, HastVisitorContext } from 'satteri'
 import type { Element } from 'rehype-expressive-code/hast'
-import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions } from 'rehype-expressive-code'
+import type { ExpressiveCodeBlockOptions, RehypeExpressiveCodeDocument, RehypeExpressiveCodeOptions, RehypeExpressiveCodeRenderer } from 'rehype-expressive-code'
+import { createRenderer, ExpressiveCodeBlock } from 'rehype-expressive-code'
 import { fileURLToPath } from 'url-extras'
-import { CodeProps } from '../components/types'
 
 type CodeBlockInfo = {
 	lang: string
@@ -11,7 +11,9 @@ type CodeBlockInfo = {
 }
 
 export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions): HastPluginDefinition {
-	const { tabWidth = 2, getBlockLocale } = options
+	const { tabWidth = 2, getBlockLocale, customCreateRenderer } = options
+	const customCreateBlock = createSatteriBlockFactory(options.customCreateBlock)
+	let asyncRenderer: Promise<RehypeExpressiveCodeRenderer> | RehypeExpressiveCodeRenderer | undefined
 	let firstBlockClaimed = false
 
 	return {
@@ -25,6 +27,11 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 				const isFirstBlock = !firstBlockClaimed
 				firstBlockClaimed = true
 
+				if (asyncRenderer === undefined) {
+					asyncRenderer = (customCreateRenderer ?? createRenderer)(options)
+				}
+				const { ec, baseStyles, themeStyles, jsModules } = await asyncRenderer
+
 				let normalizedCode = codeBlockInfo.text
 				if (tabWidth > 0) normalizedCode = normalizedCode.replace(/\t/g, ' '.repeat(tabWidth))
 
@@ -37,33 +44,46 @@ export function satteriExpressiveCodePlugin(options: RehypeExpressiveCodeOptions
 						sourceFilePath: file.path,
 					},
 				}
-				const locale = await getBlockLocale?.({ input, file })
-				const codeProps = {
-					code: input.code,
-					lang: input.language,
-					meta: input.meta,
-					locale,
-				} satisfies CodeProps
+				if (getBlockLocale) {
+					input.locale = await getBlockLocale({ input, file })
+				}
+
+				const codeBlock = await customCreateBlock({ input, file })
+				const { renderedGroupAst, styles } = await ec.render(codeBlock)
+				const extraElements: Element[] = []
+				const stylesToPrepend: string[] = []
 
 				if (isFirstBlock) {
-					ctx.insertBefore(node, {
-						type: 'mdxjsEsm',
-						value: "import { Code as ExpressiveCodeInternal } from 'astro-expressive-code/components'",
-					} as MdxjsEsm)
+					if (baseStyles) stylesToPrepend.push(baseStyles)
+					if (themeStyles) stylesToPrepend.push(themeStyles)
+				}
+				stylesToPrepend.push(...styles)
+				if (stylesToPrepend.length) {
+					extraElements.push({
+						type: 'element',
+						tagName: 'style',
+						properties: {},
+						children: [{ type: 'text', value: stylesToPrepend.join('') }],
+					})
+				}
+				if (isFirstBlock) {
+					jsModules.forEach((moduleCode) => {
+						extraElements.push({
+							type: 'element',
+							tagName: 'script',
+							properties: { type: 'module' },
+							children: [{ type: 'text', value: moduleCode }],
+						})
+					})
+				}
+				if (extraElements.length) {
+					const firstChild = renderedGroupAst.children.length > 0 ? renderedGroupAst.children[0] : undefined
+					const firstChildIsStyle = firstChild?.type === 'element' && ['style', 'link'].includes(firstChild.tagName)
+					const insertIndex = firstChildIsStyle ? 1 : 0
+					renderedGroupAst.children.splice(insertIndex, 0, ...extraElements)
 				}
 
-				return {
-					type: 'mdxJsxFlowElement',
-					name: 'ExpressiveCodeInternal',
-					attributes: Object.entries(codeProps)
-						.filter(([_, value]) => value)
-						.map(([key, value]) => ({
-							type: 'mdxJsxAttribute',
-							name: key,
-							value,
-						})),
-					children: [],
-				}
+				return renderedGroupAst
 			},
 		},
 	}
@@ -100,6 +120,24 @@ function createSatteriDocumentFile(ctx: HastVisitorContext): RehypeExpressiveCod
 				fileURL,
 			},
 		},
+	}
+}
+
+/**
+ * Wraps an optional user `customCreateBlock` so that every code block created by the Sätteri plugin
+ * receives a `positionInDocument.groupIndex`. Sätteri visits code blocks without tracking their
+ * order within a document, but our renderer uses this index to inject page-wide styles & scripts
+ * exactly once per document (before the first block it processes for each source file).
+ */
+function createSatteriBlockFactory(userCreateBlock: RehypeExpressiveCodeOptions['customCreateBlock']): NonNullable<RehypeExpressiveCodeOptions['customCreateBlock']> {
+	const groupIndexByDocument = new Map<string, number>()
+	return async ({ input, file }) => {
+		const documentKey = input.parentDocument?.sourceFilePath || file.path || ''
+		const groupIndex = groupIndexByDocument.get(documentKey) ?? 0
+		groupIndexByDocument.set(documentKey, groupIndex + 1)
+		input.parentDocument = { ...input.parentDocument, positionInDocument: { groupIndex } }
+		if (userCreateBlock) return userCreateBlock({ input, file })
+		return new ExpressiveCodeBlock(input)
 	}
 }
 

--- a/packages/astro-expressive-code/src/vite-plugin.ts
+++ b/packages/astro-expressive-code/src/vite-plugin.ts
@@ -20,14 +20,17 @@ export function vitePluginAstroExpressiveCode({
 	astroConfig,
 	command,
 }: {
-	styles: [string, string][]
+	styles: string
 	scripts: [string, string][]
 	ecIntegrationOptions: AstroExpressiveCodeOptions
 	processedEcConfig: AstroExpressiveCodeOptions
 	astroConfig: PartialAstroConfig
 	command: HookParameters<'astro:config:setup'>['command']
 }): NonNullable<ViteUserConfig['plugins']>[number] {
-	const modules: Record<string, string> = {}
+	// Map virtual module names to their code contents as strings
+	const modules: Record<string, string> = {
+		'virtual:astro-expressive-code/styles.css': processedEcConfig.emitExternalStylesheet === false ? '' : styles,
+	}
 
 	// Create virtual config module
 	const configModuleContents: string[] = []
@@ -72,7 +75,7 @@ export function vitePluginAstroExpressiveCode({
 	const getVirtualModuleContents = (source: string) => {
 		// In dev mode, serve the extracted styles & scripts as virtual modules
 		if (command === 'dev') {
-			for (const file of [...styles, ...scripts]) {
+			for (const file of scripts) {
 				const [fileName, contents] = file
 				if (noQuery(fileName) === noQuery(source)) return contents
 			}
@@ -96,7 +99,7 @@ export function vitePluginAstroExpressiveCode({
 					if (resolved) return resolved
 				}
 				// Resolve other virtual modules
-				if (getVirtualModuleContents(source)) return `\0${source}`
+				if (getVirtualModuleContents(source) !== undefined) return `\0${source}`
 			},
 			load: (id) => (id?.[0] === '\0' ? getVirtualModuleContents(id.slice(1)) : undefined),
 			// If any file imported by the EC config file changes, restart the server
@@ -144,12 +147,12 @@ export function vitePluginAstroExpressiveCode({
 			},
 		},
 		// Add a second plugin that only runs in build mode (to avoid Vite warnings about emitFile)
-		// which emits the extracted styles & scripts as static assets
+		// which emits the extracted scripts as static assets
 		{
 			name: 'vite-plugin-astro-expressive-code-build',
 			apply: 'build',
 			buildEnd() {
-				for (const file of [...styles, ...scripts]) {
+				for (const file of scripts) {
 					const [fileName, source] = file
 					this.emitFile({
 						type: 'asset',

--- a/packages/astro-expressive-code/src/vite-plugin.ts
+++ b/packages/astro-expressive-code/src/vite-plugin.ts
@@ -21,7 +21,7 @@ export function vitePluginAstroExpressiveCode({
 	command,
 }: {
 	styles: string
-	scripts: [string, string][]
+	scripts: { route: string; content: string }
 	ecIntegrationOptions: AstroExpressiveCodeOptions
 	processedEcConfig: AstroExpressiveCodeOptions
 	astroConfig: PartialAstroConfig
@@ -29,7 +29,8 @@ export function vitePluginAstroExpressiveCode({
 }): NonNullable<ViteUserConfig['plugins']>[number] {
 	// Map virtual module names to their code contents as strings
 	const modules: Record<string, string> = {
-		'virtual:astro-expressive-code/styles.css': processedEcConfig.emitExternalStylesheet === false ? '' : styles,
+		'virtual:astro-expressive-code/styles.css': styles,
+		'virtual:astro-expressive-code/scripts.js': scripts.content,
 	}
 
 	// Create virtual config module
@@ -75,10 +76,7 @@ export function vitePluginAstroExpressiveCode({
 	const getVirtualModuleContents = (source: string) => {
 		// In dev mode, serve the extracted styles & scripts as virtual modules
 		if (command === 'dev') {
-			for (const file of scripts) {
-				const [fileName, contents] = file
-				if (noQuery(fileName) === noQuery(source)) return contents
-			}
+			if (noQuery(scripts.route) === noQuery(source)) return scripts.content
 		}
 		return source in modules ? modules[source] : undefined
 	}
@@ -152,15 +150,12 @@ export function vitePluginAstroExpressiveCode({
 			name: 'vite-plugin-astro-expressive-code-build',
 			apply: 'build',
 			buildEnd() {
-				for (const file of scripts) {
-					const [fileName, source] = file
-					this.emitFile({
-						type: 'asset',
-						// Remove leading slash and any query params
-						fileName: noQuery(fileName.slice(1)),
-						source,
-					})
-				}
+				this.emitFile({
+					type: 'asset',
+					// Remove leading slash and any query params
+					fileName: noQuery(scripts.route.slice(1)),
+					source: scripts.content,
+				})
 			},
 		},
 	]

--- a/packages/astro-expressive-code/src/vite-plugin.ts
+++ b/packages/astro-expressive-code/src/vite-plugin.ts
@@ -20,7 +20,7 @@ export function vitePluginAstroExpressiveCode({
 	astroConfig,
 	command,
 }: {
-	styles: string
+	styles: { route: string; content: string }
 	scripts: { route: string; content: string }
 	ecIntegrationOptions: AstroExpressiveCodeOptions
 	processedEcConfig: AstroExpressiveCodeOptions
@@ -29,7 +29,7 @@ export function vitePluginAstroExpressiveCode({
 }): NonNullable<ViteUserConfig['plugins']>[number] {
 	// Map virtual module names to their code contents as strings
 	const modules: Record<string, string> = {
-		'virtual:astro-expressive-code/styles.css': styles,
+		'virtual:astro-expressive-code/styles.css': styles.content,
 		'virtual:astro-expressive-code/scripts.js': scripts.content,
 	}
 
@@ -71,12 +71,17 @@ export function vitePluginAstroExpressiveCode({
 	const shikiAssetRegExp = /(?<=\n)\s*\{[\s\S]*?"id": "(.*?)",[\s\S]*?\n\s*\},?\s*\n/g
 	const shikiBundledLanguagesModuleRegExp = /\/shiki\/dist\/langs(?:-bundle-full-[^/]+)?\.m?js$/
 
+	const injectCssAndJs = processedEcConfig.injectCssAndJs ?? 'inline'
+	const injectCssAndJsInline = injectCssAndJs === 'inline'
+
 	const noQuery = (source: string) => source.split('?')[0]
 
 	const getVirtualModuleContents = (source: string) => {
 		// In dev mode, serve the extracted styles & scripts as virtual modules
 		if (command === 'dev') {
-			if (noQuery(scripts.route) === noQuery(source)) return scripts.content
+			for (const resource of [styles, scripts]) {
+				if (noQuery(resource.route) === noQuery(source)) return resource.content
+			}
 		}
 		return source in modules ? modules[source] : undefined
 	}
@@ -145,17 +150,19 @@ export function vitePluginAstroExpressiveCode({
 			},
 		},
 		// Add a second plugin that only runs in build mode (to avoid Vite warnings about emitFile)
-		// which emits the extracted scripts as static assets
-		{
+		// which emits the extracted styles & scripts as static assets
+		injectCssAndJsInline && {
 			name: 'vite-plugin-astro-expressive-code-build',
 			apply: 'build',
 			buildEnd() {
-				this.emitFile({
-					type: 'asset',
-					// Remove leading slash and any query params
-					fileName: noQuery(scripts.route.slice(1)),
-					source: scripts.content,
-				})
+				for (const resource of [styles, scripts]) {
+					this.emitFile({
+						type: 'asset',
+						// Remove leading slash and any query params
+						fileName: noQuery(resource.route.slice(1)),
+						source: resource.content,
+					})
+				}
 			},
 		},
 	]

--- a/packages/astro-expressive-code/src/vite-plugin.ts
+++ b/packages/astro-expressive-code/src/vite-plugin.ts
@@ -71,6 +71,7 @@ export function vitePluginAstroExpressiveCode({
 	const shikiAssetRegExp = /(?<=\n)\s*\{[\s\S]*?"id": "(.*?)",[\s\S]*?\n\s*\},?\s*\n/g
 	const shikiBundledLanguagesModuleRegExp = /\/shiki\/dist\/langs(?:-bundle-full-[^/]+)?\.m?js$/
 
+	const emitExternalStylesheet = processedEcConfig.emitExternalStylesheet ?? true
 	const injectCssAndJs = processedEcConfig.injectCssAndJs ?? 'inline'
 	const injectCssAndJsInline = injectCssAndJs === 'inline'
 
@@ -155,7 +156,11 @@ export function vitePluginAstroExpressiveCode({
 			name: 'vite-plugin-astro-expressive-code-build',
 			apply: 'build',
 			buildEnd() {
-				for (const resource of [styles, scripts]) {
+				const resources = [emitExternalStylesheet && styles, scripts].filter(Boolean) as {
+					route: string
+					content: string
+				}[]
+				for (const resource of resources) {
 					this.emitFile({
 						type: 'asset',
 						// Remove leading slash and any query params

--- a/packages/astro-expressive-code/test/integration.test.ts
+++ b/packages/astro-expressive-code/test/integration.test.ts
@@ -932,10 +932,12 @@ async function buildFixture({
 	const fixturePath = join(__dirname, 'fixtures', fixtureDir)
 	const outputDirPath = join(fixturePath, outputDir)
 	const shimPath = join(__dirname, 'fixtures', 'astro-build-shim.cjs')
+	// escape Windows paths and white spaces
+	const escapedShimPath = `"${shimPath.replaceAll('\\', '/')}"`
 	// Some restricted environments report `os.cpus()` as an empty array.
 	// Astro 3.x can derive a build concurrency of 0 from that and crash, so we
 	// always preload a tiny shim that guarantees at least one CPU entry.
-	const nodeOptions = [process.env.NODE_OPTIONS, `--require ${shimPath}`].filter(Boolean).join(' ')
+	const nodeOptions = [process.env.NODE_OPTIONS, `--require ${escapedShimPath}`].filter(Boolean).join(' ')
 
 	if (!keepPreviousBuild) {
 		// Remove the output directory if it exists
@@ -954,7 +956,7 @@ async function buildFixture({
 		})
 
 		// Throw an error if the build command failed
-		if (buildCommandResult.failed || buildCommandResult.stderr) {
+		if (buildCommandResult.failed) {
 			throw new Error(buildCommandResult.stderr.toString())
 		}
 	}

--- a/packages/astro-expressive-code/virtual.d.ts
+++ b/packages/astro-expressive-code/virtual.d.ts
@@ -17,3 +17,5 @@ declare module 'virtual:astro-expressive-code/api' {
 }
 
 declare module 'virtual:astro-expressive-code/styles.css'
+
+declare module 'virtual:astro-expressive-code/scripts.js'

--- a/packages/astro-expressive-code/virtual.d.ts
+++ b/packages/astro-expressive-code/virtual.d.ts
@@ -17,5 +17,4 @@ declare module 'virtual:astro-expressive-code/api' {
 }
 
 declare module 'virtual:astro-expressive-code/styles.css'
-
 declare module 'virtual:astro-expressive-code/scripts.js'

--- a/packages/astro-expressive-code/virtual.d.ts
+++ b/packages/astro-expressive-code/virtual.d.ts
@@ -15,3 +15,5 @@ declare module 'virtual:astro-expressive-code/api' {
 	export const createAstroRenderer: typeof import('astro-expressive-code').createAstroRenderer
 	export const mergeEcConfigOptions: typeof import('astro-expressive-code').mergeEcConfigOptions
 }
+
+declare module 'virtual:astro-expressive-code/styles.css'


### PR DESCRIPTION
This option allows you to disable the embedded external css that blocks the rendering half ways completely or injecting it to the head to every file.

Superseds #457 (closes #457) (https://github.com/expressive-code/expressive-code/pull/457#discussion_r3486072622)
Closes #452