### PR TITLE
Fix themed scrollbar corner background

### DIFF
--- a/.changeset/clean-corners-smile.md
+++ b/.changeset/clean-corners-smile.md
@@ -1,0 +1,8 @@
+---
+'@expressive-code/core': patch
+'expressive-code': patch
+'rehype-expressive-code': patch
+'astro-expressive-code': patch
+---
+
+Prevent a white corner from appearing when themed horizontal and vertical scrollbars are both visible.

--- a/packages/@expressive-code/core/src/internal/core-styles.ts
+++ b/packages/@expressive-code/core/src/internal/core-styles.ts
@@ -311,6 +311,9 @@ export function getCoreBaseStyles({
 			&::-webkit-scrollbar-thumb:hover {
 				background-color: ${cssVar('scrollbarThumbHoverColor')};
 			}
+			&::-webkit-scrollbar-corner {
+				background: transparent;
+			}
 			`)}
 		}
 

--- a/packages/@expressive-code/core/test/engine.test.ts
+++ b/packages/@expressive-code/core/test/engine.test.ts
@@ -148,7 +148,9 @@ describe('ExpressiveCodeEngine', () => {
 		})
 		test('Scrollbar styles are enabled by default', async () => {
 			const engine = new ExpressiveCodeEngine({})
-			expect(await engine.getBaseStyles()).toMatch(/::-webkit-scrollbar/)
+			const styles = await engine.getBaseStyles()
+			expect(styles).toMatch(/::-webkit-scrollbar/)
+			expect(styles).toContain('::-webkit-scrollbar-corner{background:transparent}')
 		})
 		test('Scrollbar styles can be disabled by setting `useThemedScrollbars` to false', async () => {
 			const engine = new ExpressiveCodeEngine({ useThemedScrollbars: false })


### PR DESCRIPTION
## Summary

- make the WebKit scrollbar corner transparent when themed horizontal and vertical scrollbars are both visible
- add generated CSS regression coverage and a patch changeset

Fixes #354

## Testing

- `pnpm --filter @expressive-code/core coverage`
- `pnpm build`
- `pnpm test`
- `pnpm lint`